### PR TITLE
chore: Add a simple Makefile to encapsulate formatting

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,13 @@
+# format all files in the project
+format: dprint flutter-format
+
+dprint:
+	dprint fmt
+
+# flutter lacks a dprint plugin, use its own formatter
+flutter-format:
+	flutter format . --fix
+
+clean:
+	flutter clean
+	cd rust && cargo clean && cd -

--- a/lib/off_topic_code.dart
+++ b/lib/off_topic_code.dart
@@ -15,9 +15,7 @@ Widget buildPageUi(Uint8List? exampleImage, String? exampleText) {
       body: ListView(
         children: [
           Container(height: 16),
-            const Card(
-              child: Text("Legends of Lightning")
-              ),
+          const Card(child: Text("Legends of Lightning")),
           Container(
             padding: const EdgeInsets.symmetric(horizontal: 24),
             child: Card(


### PR DESCRIPTION
Unfortunately, I couldn't get dprint working for flutter.
As a stopgap, here's a simple Makefile that can be used to call both formatters
at once.