### PR TITLE
Provide instructions for building on all targets, including mobile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,62 @@
-# format all files in the project
+deps: deps-gen deps-android deps-ios
+
+deps-gen:
+	cargo install flutter_rust_bridge_codegen
+
+# Install dependencies for Android (build targets and cargo-ndk)
+deps-android:
+	cargo install cargo-ndk
+	rustup target add aarch64-linux-android armv7-linux-androideabi x86_64-linux-android i686-linux-android
+
+# Install dependencies for iOS
+deps-ios:
+	cargo install cargo-lipo
+	rustup target add aarch64-apple-ios x86_64-apple-ios
+
+# Format all files in the project
 format: dprint flutter-format
 
 dprint:
 	dprint fmt
 
-# flutter lacks a dprint plugin, use its own formatter
+# Flutter lacks a dprint plugin, use its own formatter
 flutter-format:
 	flutter format . --fix
 
+# Clean all build artifacts
 clean:
 	flutter clean
-	cd rust && cargo clean && cd -
+	cd rust && cargo clean
+
+# Build Rust library for native target
+native:rust
+	cd rust && cargo build
+
+# Build Rust library for Android
+android:rust
+	force-rebuild
+	cd rust && cargo ndk -o ../android/app/src/main/jniLibs build
+
+# Build Rust library for iOS
+ios:rust
+	cd rust && cargo lipo
+	cp rust/target/universal/debug/libten_ten_one.a ios/Runner
+
+# Ensure flutter is up-to-date & generate bindings
+gen:rust
+	flutter pub get
+	flutter_rust_bridge_codegen \
+		--rust-input rust/src/api.rs \
+		--dart-output lib/bridge_generated.dart \
+		--dart-format-line-length 120 \
+		--c-output ios/Runner/bridge_generated.h \
+		--c-output macos/Runner/bridge_generated.h \
+		--dart-decl-output lib/bridge_definitions.dart \
+		--wasm
+
+# Run the app (need to pick the target, if no mobile emulator is running)
+run:
+	flutter run
+
+# XXX: A workaround for Makefile weirdness - it can't notice
+force-rebuild: .

--- a/README.md
+++ b/README.md
@@ -3,17 +3,52 @@
 ## Dependencies
 
 This project requires `flutter` and `Rust`.
+A lot of complexity for building the app has been encapsulated in a [Makefile](./Makefile).
+
+To install necessary project dependencies for all targets, run the following:
+
+```sh
+make deps
+```
 
 ## Building
 
-The instructions below allow building for the native desktop on your platform.
-Instructions for building for other platforms will be added soon.
+The instructions below allow building the Rust backend for 10101 application.
+
+### Bindings to Flutter
+
+Bindings for Flutter can be generated with the following command:
 
 ```sh
-cd rust
-cargo build
-cd ..
+make gen
+```
 
-flutter pub get
+### Native (desktop)
+
+```sh
+make native
+```
+
+### iOS
+
+```sh
+make ios
+```
+
+### Android
+
+```sh
+make android
+```
+
+## Running
+
+After compiling the relevant Rust backend in the previous section, invoke Flutter:
+
+```sh
 flutter run
 ```
+
+note: Flutter might ask you which target you'd like to run.
+
+Running 10101 for `web` target in currently unsupported.


### PR DESCRIPTION
Expand Makefile to encapsulate all the convoluted commands needed.
Update README.md to mention the Makefile