### PR TITLE
chore(deps): Enable dependabot for flutter packages

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,3 +16,10 @@ updates:
     ignore:
       - dependency-name: 13rac1/block-fixup-merge-action
     open-pull-requests-limit: 10
+
+    # Flutter package updates
+  - package-ecosystem: "pub"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10


### PR DESCRIPTION
Start off with weekly updates so it's not too annoying.