### PR TITLE
chore(ci): Build and test the whole app on Android

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,3 +29,16 @@ jobs:
         run: git log --pretty=format:%s origin/main..HEAD | grep -zv fixup!
       - name: Disallow squash! commits
         run: git log --pretty=format:%s origin/main..HEAD | grep -zv squash!
+
+  # See: https://betterprogramming.pub/test-flutter-apps-on-android-with-github-actions-abdba2137b4
+  flutter_android_test:
+    name: Flutter (Android) integration test
+    strategy:
+      matrix:
+        device:
+          - "pixel"
+          - "Nexus 6"
+      fail-fast: false
+    uses: ./.github/workflows/flutter_android_test.yml
+    with:
+      device: ${{ matrix.device }}

--- a/.github/workflows/flutter_android_test.yml
+++ b/.github/workflows/flutter_android_test.yml
@@ -1,0 +1,92 @@
+# Adapted from https://github.com/fzyzcjy/flutter_rust_bridge repo
+on:
+  workflow_call:
+    inputs:
+      flutter_version:
+        required: false
+        type: string
+        default: "3.3.1"
+      rust_version:
+        required: false
+        type: string
+        default: "1.64.0"
+      device:
+        required: true
+        type: string
+      timeout_minutes:
+        required: false
+        type: number
+        default: 20
+
+jobs:
+  flutter_android_test:
+    runs-on: macos-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      # #499, https://github.com/actions/virtual-environments/issues/5595
+      - name: Configure ndk
+        run: |
+          ANDROID_HOME=$HOME/Library/Android/sdk
+          SDKMANAGER=$ANDROID_HOME/cmdline-tools/latest/bin/sdkmanager
+
+          echo y | $SDKMANAGER "ndk;21.4.7075529"
+
+          ln -sfn $ANDROID_HOME/ndk/21.4.7075529 $ANDROID_HOME/ndk-bundle
+
+      - name: Install Rust toolchain
+        id: checkout
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: ${{ inputs.rust_version }}
+          override: true
+
+      - uses: subosito/flutter-action@v2
+        with:
+          channel: "stable"
+          flutter-version: ${{ inputs.flutter_version }}
+          architecture: x64
+
+      - uses: actions/setup-java@v1
+        with:
+          java-version: "8.x" # "betterprogramming.pub" says must be java "8"
+
+      - uses: actions/cache@v3
+        id: cache-deps
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            ./rust/target
+          key: ${{ runner.os }}-cargo-integrate-android-${{ hashFiles('**/Cargo.lock') }}-${{ steps.checkout.outputs.rustc_hash }}
+
+      - name: Add Rust targets
+        run: rustup target add x86_64-linux-android
+
+      - name: Install `cargo-ndk`
+        if: steps.cache-deps.outputs.cache-hit != 'true'
+        run: cargo install cargo-ndk --force
+
+      - name: Install Flutter dependencies
+        run: flutter pub get
+
+      - name: Build Rust lib
+        working-directory: ./rust
+        # NOTE since run on simulator, need -t to be x86_64. For real devices, of course arm-like ones.
+        run: cargo ndk -t x86_64 -o ../android/app/src/main/jniLibs build
+
+      - name: Run Flutter integration tests
+        continue-on-error: true
+        timeout-minutes: ${{ inputs.timeout_minutes }}
+        uses: Wandalen/wretry.action@v1.0.25
+        with:
+          action: reactivecircus/android-emulator-runner@v2
+          with: |
+            api-level: 29
+            arch: x86_64
+            profile: ${{ inputs.device }}
+            script: flutter test integration_test/main.dart --verbose


### PR DESCRIPTION
So far the test doesn't do anything useful besides what was already in the
example found in rust-flutter-bridge repo; it serves as a basis to see that we
end-to-end test the application on Android.