### PR TITLE
chore(ci): Don't skip CI jobs when workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,8 +50,10 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           filters: |
             rust:
+              - '.github/workflows/**'
               - 'rust/**'
             flutter:
+              - '.github/workflows/**'
               - 'lib/**'
               - 'integration_test/**'
               - 'android/**'
@@ -61,7 +63,6 @@ jobs:
               - 'web/**'
               - 'windows/**'
               - 'pubspec.*'
-
   clippy:
     needs: changes
     if: ${{ needs.changes.outputs.rust == 'true' }}


### PR DESCRIPTION
Include CI workflows in detecting the `changes`, otherwise we risk merging a
faultly workflow change.

The simplest way is to just rerun both `rust` and `flutter` changes whenever a
workflow has changed.