### PR TITLE
chore(ci): Use linux instead of macos for Android integration test job

### DIFF
--- a/.github/workflows/flutter_android_test.yml
+++ b/.github/workflows/flutter_android_test.yml
@@ -20,7 +20,7 @@ on:
 
 jobs:
   flutter_android_test:
-    runs-on: macos-latest
+    runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v3
@@ -28,13 +28,13 @@ jobs:
       # #499, https://github.com/actions/virtual-environments/issues/5595
       - name: Configure ndk
         run: |
-          ANDROID_HOME=$HOME/Library/Android/sdk
-          SDKMANAGER=$ANDROID_HOME/cmdline-tools/latest/bin/sdkmanager
+          ANDROID_ROOT=/usr/local/lib/android
+          ANDROID_SDK_ROOT=${ANDROID_ROOT}/sdk
+          SDKMANAGER=${ANDROID_SDK_ROOT}/cmdline-tools/latest/bin/sdkmanager
+          echo "y" | $SDKMANAGER "ndk;21.4.7075529"
 
-          echo y | $SDKMANAGER "ndk;21.4.7075529"
-
-          ln -sfn $ANDROID_HOME/ndk/21.4.7075529 $ANDROID_HOME/ndk-bundle
-
+          ANDROID_NDK_ROOT=${ANDROID_SDK_ROOT}/ndk-bundle
+          ln -sfn $ANDROID_SDK_ROOT/ndk/21.4.7075529 $ANDROID_NDK_ROOT
       - name: Install Rust toolchain
         id: checkout
         uses: actions-rs/toolchain@v1


### PR DESCRIPTION
Ubuntu containers are less likely to exhaust our concurrency quotas.