### PR TITLE
Add service selector to dashboard

### DIFF
--- a/lib/balance.dart
+++ b/lib/balance.dart
@@ -13,7 +13,7 @@ class Balance extends StatelessWidget {
     return Consumer<BalanceModel>(
       builder: (context, balance, child) {
         return Container(
-          padding: const EdgeInsets.all(8.0),
+          padding: const EdgeInsets.only(top: 8.0, left: 8.0, right: 8.0),
           child: Column(
             children: [
               Center(
@@ -31,7 +31,7 @@ class Balance extends StatelessWidget {
               const Divider(
                 height: 30,
                 thickness: 7,
-                color: Colors.black,
+                color: Colors.grey,
                 indent: 30,
                 endIndent: 30,
               )

--- a/lib/cfd_trading.dart
+++ b/lib/cfd_trading.dart
@@ -1,0 +1,16 @@
+import 'package:flutter/material.dart';
+
+class CfdTrading extends StatelessWidget {
+  const CfdTrading({Key? key}) : super(key: key);
+
+  static const routeName = '/cfd-trading';
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+        appBar: AppBar(
+          title: const Text('CFD Trading'),
+        ),
+        body: ListView(children: const [Center(child: Text("CFD Trading tbd"))]));
+  }
+}

--- a/lib/dashboard.dart
+++ b/lib/dashboard.dart
@@ -1,6 +1,9 @@
 import 'package:flutter/material.dart';
 import 'package:ten_ten_one/balance.dart';
+import 'package:ten_ten_one/cfd_trading.dart';
+import 'package:ten_ten_one/models/service.model.dart';
 import 'package:ten_ten_one/seed.dart';
+import 'package:ten_ten_one/service_card.dart';
 
 import 'mocks.dart';
 
@@ -27,6 +30,34 @@ class _DashboardState extends State<Dashboard> {
         ),
         body: ListView(children: [
           const Balance(),
+          Expanded(
+              // Sized box necessary to achieve nested ListViews
+              child: SizedBox(
+            height: 110.0,
+            child: ListView(
+              scrollDirection: Axis.horizontal,
+              padding: const EdgeInsets.only(left: 15, right: 15),
+              children: [
+                GestureDetector(
+                  onTap: () => {
+                    Navigator.pushNamed(
+                      context,
+                      CfdTrading.routeName,
+                    )
+                  },
+                  child: const ServiceCard(Service.cfd),
+                ),
+                const ServiceCard(Service.sportsbet),
+              ],
+            ),
+          )),
+          const Divider(
+            height: 30,
+            thickness: 7,
+            color: Colors.grey,
+            indent: 30,
+            endIndent: 30,
+          ),
           GestureDetector(
               onTap: () => {
                     Navigator.pushNamed(

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart' hide Size;
 import 'package:provider/provider.dart';
+import 'package:ten_ten_one/cfd_trading.dart';
 import 'package:ten_ten_one/dashboard.dart';
 import 'package:ten_ten_one/models/balance.model.dart';
 import 'package:ten_ten_one/seed.dart';
@@ -36,6 +37,7 @@ class _TenTenOneState extends State<TenTenOneApp> {
       theme: ThemeData(primarySwatch: Colors.teal),
       routes: {
         Seed.routeName: (context) => const Seed(),
+        CfdTrading.routeName: (context) => const CfdTrading(),
       },
       home: const Dashboard(),
     );

--- a/lib/models/service.model.dart
+++ b/lib/models/service.model.dart
@@ -1,0 +1,17 @@
+import 'package:flutter/material.dart';
+
+enum ServiceGroup { trade, bets }
+
+extension ServiceGroupExtension on ServiceGroup {
+  static const labels = {Service.cfd: "Trading", Service.sportsbet: "Bets"};
+}
+
+enum Service { cfd, sportsbet }
+
+extension ServiceExtension on Service {
+  static const labels = {Service.cfd: "CFD Trading", Service.sportsbet: "Sports Bets"};
+  static const icons = {Service.cfd: Icons.insights, Service.sportsbet: Icons.sports_football};
+
+  String get label => labels[this]!;
+  IconData get icon => icons[this]!;
+}

--- a/lib/service_card.dart
+++ b/lib/service_card.dart
@@ -1,0 +1,38 @@
+import 'package:flutter/material.dart';
+import 'package:ten_ten_one/models/service.model.dart';
+
+class ServiceCard extends StatelessWidget {
+  const ServiceCard(this.service, {Key? key}) : super(key: key);
+
+  final Service service;
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+        child: Card(
+      elevation: 5,
+      color: Theme.of(context).colorScheme.surfaceVariant,
+      shape: RoundedRectangleBorder(
+        borderRadius: BorderRadius.circular(15.0),
+      ),
+      child: SizedBox(
+        width: 100,
+        height: 100,
+        child: Center(
+            child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          crossAxisAlignment: CrossAxisAlignment.center,
+          children: [
+            Icon(
+              service.icon,
+              color: Colors.black,
+              size: 60.0,
+              semanticLabel: 'Text to announce in accessibility modes',
+            ),
+            Text(service.label)
+          ],
+        )),
+      ),
+    ));
+  }
+}


### PR DESCRIPTION
Includes navigation to CFD Trading screen, but we need more complex routing and should plug in a routing library as recommended here: https://docs.flutter.dev/development/ui/navigation#using-the-navigator

<img width="437" alt="Screenshot 2022-11-01 at 3 07 23 pm" src="https://user-images.githubusercontent.com/5557790/199156891-bb0e23f8-9764-4390-9e20-29ef6e3ca39a.png">

I will work on introducing [go_router routing library](https://pub.dev/packages/go_router) so we can depict the routing between the wallet and the service screens. 

Note on naming: I don't particularly like the name `service` for trading/bets (...) - I thought about different names (e.g. `feature` or `in-app-...?`) but did not come up with anything satisfying so I just went with `service` for now.  