### PR TITLE
Add go router to allow more complex routing

### DIFF
--- a/lib/cfd_trading.dart
+++ b/lib/cfd_trading.dart
@@ -3,7 +3,7 @@ import 'package:flutter/material.dart';
 class CfdTrading extends StatelessWidget {
   const CfdTrading({Key? key}) : super(key: key);
 
-  static const routeName = '/cfd-trading';
+  static const route = '/cfd-trading';
 
   @override
   Widget build(BuildContext context) {

--- a/lib/dashboard.dart
+++ b/lib/dashboard.dart
@@ -1,11 +1,10 @@
 import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
 import 'package:ten_ten_one/balance.dart';
 import 'package:ten_ten_one/cfd_trading.dart';
 import 'package:ten_ten_one/models/service.model.dart';
 import 'package:ten_ten_one/seed.dart';
 import 'package:ten_ten_one/service_card.dart';
-
-import 'mocks.dart';
 
 class Dashboard extends StatefulWidget {
   const Dashboard({Key? key}) : super(key: key);
@@ -15,8 +14,6 @@ class Dashboard extends StatefulWidget {
 }
 
 class _DashboardState extends State<Dashboard> {
-  WalletInfo walletInfo = WalletInfo();
-
   @override
   void initState() {
     super.initState();
@@ -39,12 +36,7 @@ class _DashboardState extends State<Dashboard> {
               padding: const EdgeInsets.only(left: 15, right: 15),
               children: [
                 GestureDetector(
-                  onTap: () => {
-                    Navigator.pushNamed(
-                      context,
-                      CfdTrading.routeName,
-                    )
-                  },
+                  onTap: () => {GoRouter.of(context).go(CfdTrading.route)},
                   child: const ServiceCard(Service.cfd),
                 ),
                 const ServiceCard(Service.sportsbet),
@@ -59,13 +51,7 @@ class _DashboardState extends State<Dashboard> {
             endIndent: 30,
           ),
           GestureDetector(
-              onTap: () => {
-                    Navigator.pushNamed(
-                      context,
-                      Seed.routeName,
-                      arguments: walletInfo,
-                    )
-                  },
+              onTap: () => {GoRouter.of(context).go(Seed.route)},
               child: Card(
                 shape: const Border(left: BorderSide(color: Colors.blueGrey, width: 5)),
                 child: Column(

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -4,6 +4,7 @@ import 'package:ten_ten_one/cfd_trading.dart';
 import 'package:ten_ten_one/dashboard.dart';
 import 'package:ten_ten_one/models/balance.model.dart';
 import 'package:ten_ten_one/seed.dart';
+import 'package:go_router/go_router.dart';
 
 import 'bridge_generated/bridge_definitions.dart';
 
@@ -32,16 +33,36 @@ class _TenTenOneState extends State<TenTenOneApp> {
 
   @override
   Widget build(BuildContext context) {
-    return MaterialApp(
+    return MaterialApp.router(
       title: 'TenTenOne',
       theme: ThemeData(primarySwatch: Colors.teal),
-      routes: {
-        Seed.routeName: (context) => const Seed(),
-        CfdTrading.routeName: (context) => const CfdTrading(),
-      },
-      home: const Dashboard(),
+      routerConfig: _router,
     );
   }
+
+  final GoRouter _router = GoRouter(
+    routes: <GoRoute>[
+      GoRoute(
+          path: '/',
+          builder: (BuildContext context, GoRouterState state) {
+            return const Dashboard();
+          },
+          routes: [
+            GoRoute(
+              path: Seed.subRouteName,
+              builder: (BuildContext context, GoRouterState state) {
+                return const Seed();
+              },
+            ),
+          ]),
+      GoRoute(
+        path: CfdTrading.route,
+        builder: (BuildContext context, GoRouterState state) {
+          return const CfdTrading();
+        },
+      ),
+    ],
+  );
 
   Future<void> _callInitWallet() async {
     await api.initWallet(network: Network.Testnet);

--- a/lib/mocks.dart
+++ b/lib/mocks.dart
@@ -1,16 +1,14 @@
-class WalletInfo {
-  List<String> phrase = [
-    "blubb",
-    "blubb",
-    "blubb",
-    "blubb",
-    "blubb",
-    "blubb",
-    "blubb",
-    "blubb",
-    "blubb",
-    "blubb",
-    "blubb",
-    "blubb",
-  ];
-}
+const List<String> phrase = [
+  "blubb",
+  "blubb",
+  "blubb",
+  "blubb",
+  "blubb",
+  "blubb",
+  "blubb",
+  "blubb",
+  "blubb",
+  "blubb",
+  "blubb",
+  "blubb",
+];

--- a/lib/seed.dart
+++ b/lib/seed.dart
@@ -4,11 +4,11 @@ import 'mocks.dart';
 class Seed extends StatelessWidget {
   const Seed({Key? key}) : super(key: key);
 
-  static const routeName = '/seed';
+  static const route = '/' + subRouteName;
+  static const subRouteName = 'seed';
 
   @override
   Widget build(BuildContext context) {
-    final walletInfo = ModalRoute.of(context)!.settings.arguments as WalletInfo;
     return Scaffold(
         appBar: AppBar(
           title: const Text('Backup Seed'),
@@ -23,7 +23,7 @@ class Seed extends StatelessWidget {
                         children: [
                           const Text("Seed phrase",
                               style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold)),
-                          Text(walletInfo.phrase.toString())
+                          Text(phrase.toString())
                         ],
                       )))),
         ]));

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -247,6 +247,11 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  flutter_web_plugins:
+    dependency: transitive
+    description: flutter
+    source: sdk
+    version: "0.0.0"
   freezed:
     dependency: "direct dev"
     description:
@@ -280,6 +285,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "2.1.0"
+  go_router:
+    dependency: "direct main"
+    description:
+      name: go_router
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "5.1.1"
   graphs:
     dependency: transitive
     description:
@@ -333,7 +345,7 @@ packages:
       name: js
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.6.5"
+    version: "0.6.4"
   json_annotation:
     dependency: transitive
     description:
@@ -621,4 +633,4 @@ packages:
     version: "3.1.1"
 sdks:
   dart: ">=2.18.0 <3.0.0"
-  flutter: ">=1.16.0"
+  flutter: ">=3.3.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -39,6 +39,7 @@ dependencies:
   ffi: ^2.0.1
   provider: ^6.0.0
   intl: ^0.17.0
+  go_router: ^5.1.1
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
This allows us to specify sibling routes (e.g. wallet screen to cfd-trading screen) and parent-child (descending) routes (e.g. wallet screen to wallet-backup seed screen).