### PR TITLE
feat: Send Rust logs to flutter

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -32,6 +32,7 @@ class _TenTenOneState extends State<TenTenOneApp> {
   @override
   void initState() {
     super.initState();
+    setupRustLogging();
     _callInitWallet();
   }
 
@@ -80,6 +81,12 @@ class _TenTenOneState extends State<TenTenOneApp> {
   Future<void> _callSync() async {
     final balance = await api.getBalance();
     if (mounted) setState(() => balanceModel.update(balance.confirmed));
+  }
+
+  Future<void> setupRustLogging() async {
+    api.initLogging().listen((event) {
+      debugPrint('log from rust: ${event.msg}');
+    });
   }
 }
 

--- a/rust/src/api.rs
+++ b/rust/src/api.rs
@@ -1,6 +1,8 @@
+use crate::logger;
 use crate::wallet;
 use crate::wallet::Network;
 use anyhow::Result;
+use flutter_rust_bridge::StreamSink;
 
 pub struct Balance {
     pub confirmed: u64,
@@ -18,4 +20,9 @@ pub fn init_wallet(network: Network) -> Result<()> {
 
 pub fn get_balance() -> anyhow::Result<Balance> {
     Ok(Balance::new(wallet::get_balance()?.confirmed))
+}
+
+/// Initialise logging infrastructure for Rust
+pub fn init_logging(sink: StreamSink<logger::LogEntry>) {
+    logger::create_log_stream(sink)
 }

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -1,4 +1,5 @@
 mod api;
 mod bridge_generated;
+mod logger;
 mod seed;
 mod wallet;

--- a/rust/src/logger.rs
+++ b/rust/src/logger.rs
@@ -1,0 +1,24 @@
+use flutter_rust_bridge::StreamSink;
+use state::Storage;
+
+/// Wallet has to be managed by Rust as generics are not support by frb
+static LOG_STREAM_SINK: Storage<StreamSink<LogEntry>> = Storage::new();
+
+/// Struct to expose logs from Rust to Flutter
+pub struct LogEntry {
+    // TODO: Add more fields, including time and level
+    pub msg: String,
+}
+
+pub fn create_log_stream(sink: StreamSink<LogEntry>) {
+    LOG_STREAM_SINK.set(sink);
+}
+
+pub fn log(msg: &str) {
+    LOG_STREAM_SINK
+        .try_get()
+        .expect("logging to be initialised")
+        .add(LogEntry {
+            msg: msg.to_string(),
+        });
+}

--- a/rust/src/wallet.rs
+++ b/rust/src/wallet.rs
@@ -1,3 +1,4 @@
+use crate::logger::log;
 use crate::seed::Bip39Seed;
 use anyhow::anyhow;
 use anyhow::bail;
@@ -67,7 +68,7 @@ impl Wallet {
         self.wallet.sync(&self.blockchain, SyncOptions::default())?;
 
         let balance = self.wallet.get_balance()?;
-        println!("Wallet balance: {} SAT", &balance);
+        log(&format!("Wallet balance: {} SAT", &balance));
         Ok(balance)
     }
 }
@@ -80,7 +81,7 @@ pub fn init_wallet(network: Network) -> Result<()> {
 }
 
 pub fn get_balance() -> Result<bdk::Balance> {
-    println!("Wallet sync called");
+    log("Wallet sync called");
     WALLET
         .try_get()
         .context("Wallet uninitialised")?


### PR DESCRIPTION
Provide some basic API to stream Rust logs to Flutter and stream existing logs
    instead of using `println!` macro.

TODO: Use `tracing` infrastructure to stream the logs, instead of handcrafted function
TODO: after adding support for `tracing` and adding a Flutter log package, send
    over timestamps, log level etc.