### PR TITLE
Seed page layout fixes

### DIFF
--- a/lib/seed.dart
+++ b/lib/seed.dart
@@ -65,103 +65,102 @@ class _SeedState extends State<Seed> {
         appBar: AppBar(
           title: const Text('Backup Seed'),
         ),
-        body: Column(
-          children: [
-            Container(
-              margin: const EdgeInsets.fromLTRB(30, 30, 30, 30),
-              child: Row(mainAxisAlignment: MainAxisAlignment.center, children: [
-                Flexible(
-                  child: RichText(
-                      text: const TextSpan(
-                          style: TextStyle(color: Colors.black, fontSize: 18),
-                          children: [
-                        TextSpan(
-                            text:
-                                "This list of words is your wallet backup. Save it somewhere safe (not on this phone)! "),
-                        TextSpan(
-                            text: "\n\nDo not share it with anyone. Do not lose it. ",
-                            style: TextStyle(fontWeight: FontWeight.bold)),
-                        TextSpan(
-                            text:
-                                "If you lose your words list and your phone, you've lost your funds.")
-                      ])),
-                )
-              ]),
-            ),
-            Row(
-              children: [
-                Expanded(
-                    child: Container(
-                        margin: const EdgeInsets.fromLTRB(55, 10, 10, 0),
-                        child: Row(children: [
-                          Column(
-                              crossAxisAlignment: CrossAxisAlignment.start, children: firstColumn)
-                        ]))),
-                Expanded(
-                    child: Container(
-                        margin: const EdgeInsets.fromLTRB(10, 10, 55, 0),
-                        child: Row(children: [
-                          Column(
-                              crossAxisAlignment: CrossAxisAlignment.start, children: secondColumn)
-                        ]))),
-              ],
-            ),
-            Container(
-              margin: const EdgeInsets.symmetric(horizontal: 0, vertical: 40),
-              child: Row(
-                mainAxisAlignment: MainAxisAlignment.center,
-                children: [
-                  IconButton(
-                      icon: visibility
-                          ? const Icon(Icons.visibility)
-                          : const Icon(Icons.visibility_off),
-                      onPressed: () {
-                        setState(() {
-                          visibility = !visibility;
-                        });
-                      },
-                      tooltip: visibility ? 'Hide Seed' : 'Show Seed'),
-                  Text(visibility ? 'Hide Seed' : 'Show Seed')
-                ],
+        body: Padding(
+          padding: const EdgeInsets.all(20.0),
+          child: Column(
+            children: [
+              Center(
+                child: RichText(
+                    text: const TextSpan(
+                        style: TextStyle(color: Colors.black, fontSize: 18),
+                        children: [
+                      TextSpan(
+                          text:
+                              "This list of words is your wallet backup. Save it somewhere safe (not on this phone)! "),
+                      TextSpan(
+                          text: "\n\nDo not share it with anyone. Do not lose it. ",
+                          style: TextStyle(fontWeight: FontWeight.bold)),
+                      TextSpan(
+                          text:
+                              "If you lose your words list and your phone, you've lost your funds.")
+                    ])),
               ),
-            ),
-            Expanded(
-              child: Container(
-                  margin: const EdgeInsets.fromLTRB(0, 0, 20, 30),
+              Expanded(
+                child: Container(
+                  padding: const EdgeInsets.all(20.0),
                   child: Column(
-                    mainAxisAlignment: MainAxisAlignment.end,
                     children: [
                       Row(
                         mainAxisAlignment: MainAxisAlignment.center,
+                        crossAxisAlignment: CrossAxisAlignment.center,
                         children: [
-                          Checkbox(
-                              value: checked,
-                              onChanged: (bool? changed) {
-                                setState(() {
-                                  checked = changed!;
-                                });
-                              }),
-                          const Text('I have made a backup of my seed'),
+                          Column(
+                              crossAxisAlignment: CrossAxisAlignment.start, children: firstColumn),
+                          const SizedBox(width: 10),
+                          Column(
+                              crossAxisAlignment: CrossAxisAlignment.start, children: secondColumn)
                         ],
                       ),
-                      Row(
-                        mainAxisAlignment: MainAxisAlignment.end,
-                        children: [
-                          ElevatedButton(
-                              onPressed: checked
-                                  ? () {
-                                      final seedBackupModel = context.read<SeedBackupModel>();
-                                      seedBackupModel.update();
-                                      context.go('/');
-                                    }
-                                  : null,
-                              child: const Text('Done'))
-                        ],
-                      )
+                      const SizedBox(height: 10),
+                      Center(
+                        child: Row(
+                          mainAxisAlignment: MainAxisAlignment.center,
+                          crossAxisAlignment: CrossAxisAlignment.center,
+                          children: [
+                            IconButton(
+                                icon: visibility
+                                    ? const Icon(Icons.visibility)
+                                    : const Icon(Icons.visibility_off),
+                                onPressed: () {
+                                  setState(() {
+                                    visibility = !visibility;
+                                  });
+                                },
+                                tooltip: visibility ? 'Hide Seed' : 'Show Seed'),
+                            Text(visibility ? 'Hide Seed' : 'Show Seed')
+                          ],
+                        ),
+                      ),
                     ],
-                  )),
-            )
-          ],
+                  ),
+                ),
+              ),
+              Center(
+                child: Column(
+                  mainAxisAlignment: MainAxisAlignment.end,
+                  children: [
+                    Row(
+                      mainAxisAlignment: MainAxisAlignment.center,
+                      children: [
+                        Checkbox(
+                            value: checked,
+                            onChanged: (bool? changed) {
+                              setState(() {
+                                checked = changed!;
+                              });
+                            }),
+                        const Text('I have made a backup of my seed'),
+                      ],
+                    ),
+                    Row(
+                      mainAxisAlignment: MainAxisAlignment.end,
+                      children: [
+                        ElevatedButton(
+                            onPressed: checked
+                                ? () {
+                                    final seedBackupModel = context.read<SeedBackupModel>();
+                                    seedBackupModel.update();
+                                    context.go('/');
+                                  }
+                                : null,
+                            child: const Text('Done'))
+                      ],
+                    )
+                  ],
+                ),
+              )
+            ],
+          ),
         ));
   }
 }
@@ -181,9 +180,12 @@ class SeedWord extends StatelessWidget {
             crossAxisAlignment: visibility ? CrossAxisAlignment.baseline : CrossAxisAlignment.end,
             textBaseline: TextBaseline.alphabetic,
             children: [
-              Text(
-                '#$index',
-                style: TextStyle(fontSize: 12, color: Colors.grey[600]),
+              SizedBox(
+                width: 25.0,
+                child: Text(
+                  '#$index',
+                  style: TextStyle(fontSize: 12, color: Colors.grey[600]),
+                ),
               ),
               const SizedBox(width: 5),
               visibility

--- a/lib/seed.dart
+++ b/lib/seed.dart
@@ -62,106 +62,105 @@ class _SeedState extends State<Seed> {
         .toList();
 
     return Scaffold(
-        appBar: AppBar(
-          title: const Text('Backup Seed'),
-        ),
-        body: Padding(
-          padding: const EdgeInsets.all(20.0),
-          child: Column(
-            children: [
-              Center(
-                child: RichText(
-                    text: const TextSpan(
-                        style: TextStyle(color: Colors.black, fontSize: 18),
-                        children: [
-                      TextSpan(
-                          text:
-                              "This list of words is your wallet backup. Save it somewhere safe (not on this phone)! "),
-                      TextSpan(
-                          text: "\n\nDo not share it with anyone. Do not lose it. ",
-                          style: TextStyle(fontWeight: FontWeight.bold)),
-                      TextSpan(
-                          text:
-                              "If you lose your words list and your phone, you've lost your funds.")
-                    ])),
-              ),
-              Expanded(
-                child: Container(
-                  padding: const EdgeInsets.all(20.0),
-                  child: Column(
-                    children: [
-                      Row(
-                        mainAxisAlignment: MainAxisAlignment.center,
-                        crossAxisAlignment: CrossAxisAlignment.center,
-                        children: [
-                          Column(
-                              crossAxisAlignment: CrossAxisAlignment.start, children: firstColumn),
-                          const SizedBox(width: 10),
-                          Column(
-                              crossAxisAlignment: CrossAxisAlignment.start, children: secondColumn)
-                        ],
-                      ),
-                      const SizedBox(height: 10),
-                      Center(
-                        child: Row(
-                          mainAxisAlignment: MainAxisAlignment.center,
-                          crossAxisAlignment: CrossAxisAlignment.center,
-                          children: [
-                            IconButton(
-                                icon: visibility
-                                    ? const Icon(Icons.visibility)
-                                    : const Icon(Icons.visibility_off),
-                                onPressed: () {
-                                  setState(() {
-                                    visibility = !visibility;
-                                  });
-                                },
-                                tooltip: visibility ? 'Hide Seed' : 'Show Seed'),
-                            Text(visibility ? 'Hide Seed' : 'Show Seed')
-                          ],
-                        ),
-                      ),
-                    ],
-                  ),
-                ),
-              ),
-              Center(
+      appBar: AppBar(
+        title: const Text('Backup Seed'),
+      ),
+      body: SafeArea(
+          child: Padding(
+        padding: const EdgeInsets.all(20.0),
+        child: Column(
+          children: [
+            Center(
+              child: RichText(
+                  text: const TextSpan(
+                      style: TextStyle(color: Colors.black, fontSize: 18),
+                      children: [
+                    TextSpan(
+                        text:
+                            "This list of words is your wallet backup. Save it somewhere safe (not on this phone)! "),
+                    TextSpan(
+                        text: "\n\nDo not share it with anyone. Do not lose it. ",
+                        style: TextStyle(fontWeight: FontWeight.bold)),
+                    TextSpan(
+                        text: "If you lose your words list and your phone, you've lost your funds.")
+                  ])),
+            ),
+            Expanded(
+              child: Container(
+                padding: const EdgeInsets.all(20.0),
                 child: Column(
-                  mainAxisAlignment: MainAxisAlignment.end,
                   children: [
                     Row(
                       mainAxisAlignment: MainAxisAlignment.center,
+                      crossAxisAlignment: CrossAxisAlignment.center,
                       children: [
-                        Checkbox(
-                            value: checked,
-                            onChanged: (bool? changed) {
-                              setState(() {
-                                checked = changed!;
-                              });
-                            }),
-                        const Text('I have made a backup of my seed'),
+                        Column(crossAxisAlignment: CrossAxisAlignment.start, children: firstColumn),
+                        const SizedBox(width: 10),
+                        Column(crossAxisAlignment: CrossAxisAlignment.start, children: secondColumn)
                       ],
                     ),
-                    Row(
-                      mainAxisAlignment: MainAxisAlignment.end,
-                      children: [
-                        ElevatedButton(
-                            onPressed: checked
-                                ? () {
-                                    final seedBackupModel = context.read<SeedBackupModel>();
-                                    seedBackupModel.update();
-                                    context.go('/');
-                                  }
-                                : null,
-                            child: const Text('Done'))
-                      ],
-                    )
+                    const SizedBox(height: 10),
+                    Center(
+                      child: Row(
+                        mainAxisAlignment: MainAxisAlignment.center,
+                        crossAxisAlignment: CrossAxisAlignment.center,
+                        children: [
+                          IconButton(
+                              icon: visibility
+                                  ? const Icon(Icons.visibility)
+                                  : const Icon(Icons.visibility_off),
+                              onPressed: () {
+                                setState(() {
+                                  visibility = !visibility;
+                                });
+                              },
+                              tooltip: visibility ? 'Hide Seed' : 'Show Seed'),
+                          Text(visibility ? 'Hide Seed' : 'Show Seed')
+                        ],
+                      ),
+                    ),
                   ],
                 ),
-              )
-            ],
-          ),
-        ));
+              ),
+            ),
+            Center(
+              child: Column(
+                mainAxisAlignment: MainAxisAlignment.end,
+                children: [
+                  Row(
+                    mainAxisAlignment: MainAxisAlignment.center,
+                    children: [
+                      Checkbox(
+                          value: checked,
+                          onChanged: (bool? changed) {
+                            setState(() {
+                              checked = changed!;
+                            });
+                          }),
+                      const Text('I have made a backup of my seed'),
+                    ],
+                  ),
+                  Row(
+                    mainAxisAlignment: MainAxisAlignment.end,
+                    children: [
+                      ElevatedButton(
+                          onPressed: checked
+                              ? () {
+                                  final seedBackupModel = context.read<SeedBackupModel>();
+                                  seedBackupModel.update();
+                                  context.go('/');
+                                }
+                              : null,
+                          child: const Text('Done'))
+                    ],
+                  )
+                ],
+              ),
+            )
+          ],
+        ),
+      )),
+    );
   }
 }
 


### PR DESCRIPTION
In an effort to get a better hang of how flutter works and make sure our screen layout is at least somewhat responsive (the wireframes were for iPhone SE...) I worked on the layout of the seed screen.

I will see to apply my learnings to other detail / confirmation screens next :)

This is how it looks on different devices now:

![image](https://user-images.githubusercontent.com/5557790/200226186-8c3670d8-e12c-4321-ad61-ac5698897bce.png)

![image](https://user-images.githubusercontent.com/5557790/200226207-394abe29-a866-4fee-b4ca-4f3a34120bcb.png)


---

Note: 

I went one step further and used a FAB for confirmation as well using this code:

```dart
        floatingActionButton: FloatingActionButton.extended(
            backgroundColor: checked ? Theme.of(context).colorScheme.primary : Colors.grey[300],
            foregroundColor: checked ? Colors.black : Colors.grey[600],
            onPressed: checked
                ? () {
                    final seedBackupModel = context.read<SeedBackupModel>();
                    seedBackupModel.update();
                    context.go('/');
                  }
                : null,
            label: const Text('Done'))
```

But then I read this discussion https://github.com/flutter/flutter/issues/76120 and came to the conclusion that we should not use a FAB then. I still think a FAB that can be "disabled" looks nicer, but better not go against the recommendations.