### PR TITLE
Update flutter-rust-bridge

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -217,7 +217,7 @@ packages:
       name: ffigen
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "6.1.2"
+    version: "7.2.0"
   file:
     dependency: transitive
     description:
@@ -785,6 +785,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "3.1.1"
+  yaml_edit:
+    dependency: transitive
+    description:
+      name: yaml_edit
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.0.3"
 sdks:
   dart: ">=2.18.0 <3.0.0"
   flutter: ">=3.3.0"

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -255,7 +255,7 @@ packages:
       name: flutter_rust_bridge
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.49.0"
+    version: "1.49.1"
   flutter_speed_dial:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -30,7 +30,7 @@ dependencies:
   flutter:
     sdk: flutter
 
-  flutter_rust_bridge: ^1.49.0
+  flutter_rust_bridge: ^1.49.1
 
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -61,7 +61,7 @@ dev_dependencies:
   flutter_lints: ^1.0.0
   freezed: ^2.2.1
   build_runner: ^2.2.0
-  ffigen: ^6.0.1
+  ffigen: ^7.2.0
 
 # For information on the generic Dart part of this file, see the
 # following page: https://dart.dev/tools/pub/pubspec

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -12,7 +12,7 @@ anyhow = { version = "1", features = ["backtrace"] }
 atty = "0.2"
 bdk = "0.24.0"
 bip39 = "1.0.1"
-flutter_rust_bridge = "1.49.0"
+flutter_rust_bridge = "1.49.1"
 hkdf = "0.12"
 rand = "^0.6.0"
 sha2 = "0.10"


### PR DESCRIPTION
Update Flutter and Rust packages, and the ffigen.
Requires bumping system-wide binary:
`cargo install flutter_rust_bridge_codegen`