### PR TITLE
Rust log improvements

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -146,7 +146,11 @@ class _TenTenOneState extends State<TenTenOneApp> {
 
   Future<void> setupRustLogging() async {
     api.initLogging().listen((event) {
-      FLog.logThis(text: 'log from rust: ${event.msg}', type: LogLevel.DEBUG);
+      // Only log to Dart file in release mode - in debug mode it's easier to
+      // use stdout
+      if (foundation.kReleaseMode) {
+        FLog.logThis(text: '${event.target}: ${event.msg}', type: LogLevel.DEBUG);
+      }
     });
   }
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,7 +1,7 @@
 import 'dart:async';
 
 import 'package:f_logs/f_logs.dart';
-// import 'package:flutter/foundation.dart' as foundation;
+import 'package:flutter/foundation.dart' as foundation;
 import 'package:path_provider/path_provider.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_rust_bridge/flutter_rust_bridge.dart';
@@ -33,9 +33,7 @@ void main() {
   };
 
   final config = FLog.getDefaultConfigurations();
-  // TODO: Rethink whether we need to show Rust logs from Flutter natively or
-  // via Flutter
-  // config.activeLogLevel = foundation.kReleaseMode ? LogLevel.INFO : LogLevel.DEBUG;
+  config.activeLogLevel = foundation.kReleaseMode ? LogLevel.INFO : LogLevel.DEBUG;
 
   FLog.applyConfigurations(config);
 

--- a/rust/src/logger.rs
+++ b/rust/src/logger.rs
@@ -2,6 +2,7 @@ use anyhow::Context;
 use anyhow::Result;
 use flutter_rust_bridge::StreamSink;
 use state::Storage;
+use std::sync::Once;
 use time::macros::format_description;
 use tracing_subscriber::filter::Directive;
 use tracing_subscriber::filter::LevelFilter;

--- a/rust/src/logger.rs
+++ b/rust/src/logger.rs
@@ -13,6 +13,11 @@ use tracing_subscriber::Layer;
 
 const RUST_LOG_ENV: &str = "RUST_LOG";
 
+static INIT_LOGGER_ONCE: Once = Once::new();
+
+/// Wallet has to be managed by Rust as generics are not support by frb
+static LOG_STREAM_SINK: Storage<StreamSink<LogEntry>> = Storage::new();
+
 // Tracing log directives config
 fn log_base_directives(env: EnvFilter, level: LevelFilter) -> Result<EnvFilter> {
     let filter = env
@@ -20,9 +25,6 @@ fn log_base_directives(env: EnvFilter, level: LevelFilter) -> Result<EnvFilter> 
         .add_directive("bdk=warn".parse()?); // bdk is quite spamy on debug
     Ok(filter)
 }
-
-/// Wallet has to be managed by Rust as generics are not support by frb
-static LOG_STREAM_SINK: Storage<StreamSink<LogEntry>> = Storage::new();
 
 /// Struct to expose logs from Rust to Flutter
 pub struct LogEntry {
@@ -33,9 +35,10 @@ pub struct LogEntry {
 }
 
 pub fn create_log_stream(sink: StreamSink<LogEntry>) {
-    // TODO: Move in a different spot
     LOG_STREAM_SINK.set(sink);
-    init_tracing(LevelFilter::DEBUG, false).expect("Logger to initialise");
+    INIT_LOGGER_ONCE.call_once(|| {
+        init_tracing(LevelFilter::DEBUG, false).expect("Logger to initialise");
+    });
 }
 
 /// Tracing layer responsible for sending tracing events into


### PR DESCRIPTION
- fix a problem (potential multiple inits of tracing)
- address @holzeis comment from previous review (reenable Flutter debug logs)
- only send logs to Dart in release mode (we don't need them in debug, as we see them on stdout)