### PR TITLE
feat: Path Application Support directory from Flutter

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 
 import 'package:f_logs/f_logs.dart';
 // import 'package:flutter/foundation.dart' as foundation;
+import 'package:path_provider/path_provider.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_rust_bridge/flutter_rust_bridge.dart';
 import 'package:provider/provider.dart';
@@ -126,7 +127,8 @@ class _TenTenOneState extends State<TenTenOneApp> {
   );
 
   Future<void> _callInitWallet() async {
-    await api.initWallet(network: Network.Testnet);
+    final appSupportDir = await getApplicationSupportDirectory();
+    await api.initWallet(network: Network.Testnet, path: appSupportDir.path);
 
     // initial sync
     _callSync();

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -466,7 +466,7 @@ packages:
     source: hosted
     version: "1.0.1"
   path_provider:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: path_provider
       url: "https://pub.dartlang.org"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -46,6 +46,7 @@ dependencies:
   decimal: ^2.3.0
   font_awesome_flutter: ^10.2.1
   uuid: 3.0.6
+  path_provider: ^2.0.11
 
 dev_dependencies:
   flutter_test:

--- a/rust/src/api.rs
+++ b/rust/src/api.rs
@@ -3,6 +3,7 @@ use crate::wallet;
 use crate::wallet::Network;
 use anyhow::Result;
 use flutter_rust_bridge::StreamSink;
+use std::path::Path;
 
 pub struct Balance {
     pub confirmed: u64,
@@ -14,8 +15,8 @@ impl Balance {
     }
 }
 
-pub fn init_wallet(network: Network) -> Result<()> {
-    wallet::init_wallet(network)
+pub fn init_wallet(network: Network, path: String) -> Result<()> {
+    wallet::init_wallet(network, Path::new(path.as_str()))
 }
 
 pub fn get_balance() -> Result<Balance> {


### PR DESCRIPTION
According to the docs, Application Support directory is supported on all platforms.
This should allow us to store wallet-related files on disk.