### PR TITLE
chore: Remove `data_dir` argument

### DIFF
--- a/rust/src/api.rs
+++ b/rust/src/api.rs
@@ -42,16 +42,10 @@ pub fn get_balance() -> Result<Balance> {
 pub fn get_address() -> Result<Address> {
     Ok(Address::new(wallet::get_address()?.to_string()))
 }
-pub fn open_channel(
-    peer_pubkey_and_ip_addr: String,
-    channel_amount_sat: u64,
-    path: String,
-) -> Result<()> {
+pub fn open_channel(peer_pubkey_and_ip_addr: String, channel_amount_sat: u64) -> Result<()> {
     let peer_info = parse_peer_info(peer_pubkey_and_ip_addr)?;
     let rt = Runtime::new()?;
-    rt.block_on(async {
-        wallet::open_channel(peer_info, channel_amount_sat, Path::new(path.as_str())).await
-    })
+    rt.block_on(async { wallet::open_channel(peer_info, channel_amount_sat).await })
 }
 
 /// Initialise logging infrastructure for Rust

--- a/rust/src/lightning.rs
+++ b/rust/src/lightning.rs
@@ -49,6 +49,7 @@ use std::fmt;
 use std::iter;
 use std::net::SocketAddr;
 use std::path::Path;
+use std::path::PathBuf;
 use std::sync::atomic::AtomicBool;
 use std::sync::atomic::Ordering;
 use std::sync::Arc;
@@ -67,6 +68,7 @@ pub struct LightningSystem {
     pub keys_manager: Arc<KeysManager>,
     pub persister: Arc<FilesystemPersister>,
     pub gossip_sync: Arc<LdkGossipSync>,
+    pub data_dir: PathBuf,
 }
 
 pub struct PeerInfo {
@@ -372,17 +374,14 @@ pub fn setup(
         keys_manager,
         persister,
         gossip_sync,
+        data_dir: Path::new(&ldk_data_dir).to_path_buf(),
     };
 
     Ok(system)
 }
 
-pub async fn run_ldk(
-    system: &LightningSystem,
-    listening_port: u16,
-    ldk_data_dir: &Path,
-) -> Result<()> {
-    let ldk_data_dir = ldk_data_dir.to_string_lossy().to_string();
+pub async fn run_ldk(system: &LightningSystem, listening_port: u16) -> Result<()> {
+    let ldk_data_dir = system.data_dir.to_string_lossy().to_string();
     let peer_manager_connection_handler = system.peer_manager.clone();
     let stop_listen_connect = Arc::new(AtomicBool::new(false));
     let stop_listen = Arc::clone(&stop_listen_connect);

--- a/rust/src/wallet.rs
+++ b/rust/src/wallet.rs
@@ -68,7 +68,7 @@ impl Wallet {
         let lightning_seed = &seed.seed()[0..32].try_into()?;
 
         let lightning = lightning::setup(lightning_wallet, network, &data_dir, lightning_seed)?;
-        lightning::run_ldk(&lightning, listening_port, &data_dir).await?;
+        lightning::run_ldk(&lightning, listening_port).await?;
 
         Ok(Wallet { lightning, seed })
     }
@@ -134,16 +134,13 @@ pub fn get_seed_phrase() -> Result<Vec<String>> {
     Ok(seed_phrase)
 }
 
-pub async fn open_channel(
-    peer_info: PeerInfo,
-    channel_amount_sat: u64,
-    data_dir: &Path,
-) -> Result<()> {
-    let (peer_manager, channel_manager) = {
+pub async fn open_channel(peer_info: PeerInfo, channel_amount_sat: u64) -> Result<()> {
+    let (peer_manager, channel_manager, data_dir) = {
         let lightning = &get_wallet()?.lightning;
         (
             lightning.peer_manager.clone(),
             lightning.channel_manager.clone(),
+            lightning.data_dir.clone(),
         )
     };
 
@@ -152,7 +149,7 @@ pub async fn open_channel(
         channel_manager,
         peer_info,
         channel_amount_sat,
-        data_dir,
+        data_dir.as_path(),
     )
     .await
 }

--- a/rust/src/wallet.rs
+++ b/rust/src/wallet.rs
@@ -78,10 +78,10 @@ impl Wallet {
             .wallet
             .sync(self.lightning.confirmables())
             .map_err(|_| anyhow!("Could lot sync bdk-ldk wallet"))?;
-        self.get_balance()
+        self.get_bdk_balance()
     }
 
-    fn get_balance(&self) -> Result<bdk::Balance> {
+    fn get_bdk_balance(&self) -> Result<bdk::Balance> {
         let balance = self
             .lightning
             .wallet


### PR DESCRIPTION
Store the `data_dir` inside `LightningSystem` so that API can be simpler.