### PR TITLE
chore: Split initialisation and running of LDK

### DIFF
--- a/rust/src/lightning.rs
+++ b/rust/src/lightning.rs
@@ -73,6 +73,7 @@ use std::time::Duration;
 use std::time::SystemTime;
 
 /// Container to keep all the components of the lightning network in one place
+#[derive(Clone)]
 pub struct LightningSystem {
     pub wallet: Arc<BdkLdkWallet>,
     pub chain_monitor: Arc<ChainMonitor>,


### PR DESCRIPTION
Without this, we are susceptible to a race condition (we need to *hope* that bdk
init will happen before we start other tasks depending on it). If we explicitly
wait for init first, we don't have such a problem.

Add `Clone` trait implementation to Wallet, so that we don't need to hold the mutex to the
wallet when passing some of its data around.
Note: cloning is pretty cheap here, because we're cloning only a bunch of Arc
pointers, not the underlying wallet data.

This makes the API more discoverable, allowing for the usage
`wallet.run_ldk(port)`.