### PR TITLE
Bitcoin payment history instead of mock data

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -10,6 +10,8 @@ import 'package:ten_ten_one/bridge_generated/bridge_definitions.dart';
 import 'package:ten_ten_one/cfd_trading/cfd_order_confirmation.dart';
 import 'package:ten_ten_one/cfd_trading/cfd_order_detail.dart';
 import 'package:ten_ten_one/cfd_trading/cfd_trading.dart';
+import 'package:ten_ten_one/models/payment.model.dart';
+import 'package:ten_ten_one/payment_history_change_notifier.dart';
 import 'package:ten_ten_one/wallet/deposit.dart';
 import 'package:ten_ten_one/wallet/open_channel.dart';
 import 'package:ten_ten_one/wallet/wallet.dart';
@@ -30,6 +32,7 @@ import 'package:ten_ten_one/ffi.io.dart' if (dart.library.html) 'ffi.web.dart';
 LightningBalance lightningBalance = LightningBalance();
 BitcoinBalance bitcoinBalance = BitcoinBalance();
 SeedBackupModel seedBackup = SeedBackupModel();
+PaymentHistory paymentHistory = PaymentHistory();
 
 void main() {
   FlutterError.onError = (details) {
@@ -45,6 +48,7 @@ void main() {
     ChangeNotifierProvider(create: (context) => lightningBalance),
     ChangeNotifierProvider(create: (context) => bitcoinBalance),
     ChangeNotifierProvider(create: (context) => seedBackup),
+    ChangeNotifierProvider(create: (context) => paymentHistory),
     ChangeNotifierProvider(create: (context) => CfdTradingChangeNotifier()),
     ChangeNotifierProvider(create: (context) => WalletChangeNotifier()),
   ], child: const TenTenOneApp()));
@@ -154,8 +158,10 @@ class _TenTenOneState extends State<TenTenOneApp> {
 
     // initial sync
     _callSync();
+    _callSyncPaymentHistory();
     // consecutive syncs
     runPeriodically(_callSync);
+    runPeriodically(_callSyncPaymentHistory);
   }
 
   Future<void> _callSync() async {
@@ -165,6 +171,26 @@ class _TenTenOneState extends State<TenTenOneApp> {
       FLog.trace(text: 'Successfully synced Bitcoin wallet');
     } on FfiException catch (error) {
       FLog.error(text: 'Failed to sync Bitcoin wallet: Error: ' + error.message, exception: error);
+    }
+  }
+
+  Future<void> _callSyncPaymentHistory() async {
+    try {
+      final bitcoinTxHistory = await api.getBitcoinTxHistory();
+
+      var bph = bitcoinTxHistory
+          .map((bitcoinTxHistoryItem) => PaymentHistoryItem(
+              bitcoinTxHistoryItem.sent != 0
+                  ? Amount(bitcoinTxHistoryItem.sent)
+                  : Amount(bitcoinTxHistoryItem.received),
+              bitcoinTxHistoryItem.sent != 0 ? PaymentType.withdraw : PaymentType.deposit,
+              bitcoinTxHistoryItem.isConfirmed ? PaymentStatus.finalized : PaymentStatus.pending))
+          .toList();
+
+      paymentHistory.update(bph);
+      FLog.trace(text: 'Successfully synced payment history');
+    } on FfiException catch (error) {
+      FLog.error(text: 'Failed to sync payment history: ' + error.message, exception: error);
     }
   }
 

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -27,9 +27,9 @@ import 'package:ten_ten_one/wallet/withdraw.dart';
 
 import 'package:ten_ten_one/ffi.io.dart' if (dart.library.html) 'ffi.web.dart';
 
-LightningBalance lightningBalanceModel = LightningBalance();
-BitcoinBalance bitcoinBalanceModel = BitcoinBalance();
-SeedBackupModel seedBackupModel = SeedBackupModel();
+LightningBalance lightningBalance = LightningBalance();
+BitcoinBalance bitcoinBalance = BitcoinBalance();
+SeedBackupModel seedBackup = SeedBackupModel();
 
 void main() {
   FlutterError.onError = (details) {
@@ -42,9 +42,9 @@ void main() {
   FLog.applyConfigurations(config);
 
   runApp(MultiProvider(providers: [
-    ChangeNotifierProvider(create: (context) => lightningBalanceModel),
-    ChangeNotifierProvider(create: (context) => bitcoinBalanceModel),
-    ChangeNotifierProvider(create: (context) => seedBackupModel),
+    ChangeNotifierProvider(create: (context) => lightningBalance),
+    ChangeNotifierProvider(create: (context) => bitcoinBalance),
+    ChangeNotifierProvider(create: (context) => seedBackup),
     ChangeNotifierProvider(create: (context) => CfdTradingChangeNotifier()),
     ChangeNotifierProvider(create: (context) => WalletChangeNotifier()),
   ], child: const TenTenOneApp()));
@@ -161,7 +161,7 @@ class _TenTenOneState extends State<TenTenOneApp> {
   Future<void> _callSync() async {
     try {
       final balance = await api.getBalance();
-      bitcoinBalanceModel.update(Amount(balance.confirmed));
+      bitcoinBalance.update(Amount(balance.confirmed));
       FLog.trace(text: 'Successfully synced Bitcoin wallet');
     } on FfiException catch (error) {
       FLog.error(text: 'Failed to sync Bitcoin wallet: Error: ' + error.message, exception: error);

--- a/lib/mocks/payment_history.dart
+++ b/lib/mocks/payment_history.dart
@@ -3,44 +3,44 @@ import 'dart:math';
 import '../models/amount.model.dart';
 import '../models/payment.model.dart';
 
-List<PaymentHistoryItemItem> mockPaymentHistory(int count) {
-  return List<PaymentHistoryItemItem>.generate(count, (index) => mockPaymentHistoryItem());
+List<PaymentHistoryItem> mockPaymentHistory(int count) {
+  return List<PaymentHistoryItem>.generate(count, (index) => mockPaymentHistoryItem());
 }
 
-List<PaymentHistoryItemItem> mockPaymentHistoryLightning(int count) {
-  return List<PaymentHistoryItemItem>.generate(count, (index) => mockPaymentHistoryItem());
+List<PaymentHistoryItem> mockPaymentHistoryLightning(int count) {
+  return List<PaymentHistoryItem>.generate(count, (index) => mockPaymentHistoryItem());
 }
 
-List<PaymentHistoryItemItem> mockPaymentHistoryBitcoin(int count) {
-  return List<PaymentHistoryItemItem>.generate(count, (index) => mockPaymentHistoryItemBitcoin());
+List<PaymentHistoryItem> mockPaymentHistoryBitcoin(int count) {
+  return List<PaymentHistoryItem>.generate(count, (index) => mockPaymentHistoryItemBitcoin());
 }
 
-PaymentHistoryItemItem mockPaymentHistoryItem() {
+PaymentHistoryItem mockPaymentHistoryItem() {
   const min = -10000;
   const max = 10000;
   final randomAmount = Random().nextInt(max - min) + min;
   final randomType = Random().nextInt(7);
 
-  return PaymentHistoryItemItem(
+  return PaymentHistoryItem(
       Amount(randomAmount), PaymentType.values[randomType], PaymentStatus.finalized);
 }
 
-PaymentHistoryItemItem mockPaymentHistoryItemBitcoin() {
+PaymentHistoryItem mockPaymentHistoryItemBitcoin() {
   const min = -10000;
   const max = 10000;
   final randomAmount = Random().nextInt(max - min) + min;
   final randomBitcoinType = Random().nextInt(3);
 
-  return PaymentHistoryItemItem(
+  return PaymentHistoryItem(
       Amount(randomAmount), PaymentType.values[randomBitcoinType], PaymentStatus.finalized);
 }
 
-PaymentHistoryItemItem mockPaymentHistoryItemLightning() {
+PaymentHistoryItem mockPaymentHistoryItemLightning() {
   const min = -10000;
   const max = 10000;
   final randomAmount = Random().nextInt(max - min) + min;
   final randomLightningType = Random().nextInt(5) + 2;
 
-  return PaymentHistoryItemItem(
+  return PaymentHistoryItem(
       Amount(randomAmount), PaymentType.values[randomLightningType], PaymentStatus.finalized);
 }

--- a/lib/models/payment.model.dart
+++ b/lib/models/payment.model.dart
@@ -1,11 +1,11 @@
 import 'package:ten_ten_one/models/amount.model.dart';
 
-class PaymentHistoryItemItem {
+class PaymentHistoryItem {
   PaymentType type;
   PaymentStatus status;
   Amount amount;
 
-  PaymentHistoryItemItem(this.amount, this.type, this.status);
+  PaymentHistoryItem(this.amount, this.type, this.status);
 }
 
 enum PaymentStatus { pending, finalized }

--- a/lib/models/payment.model.dart
+++ b/lib/models/payment.model.dart
@@ -31,8 +31,8 @@ enum PaymentType {
 
 extension PaymentTypeExtension on PaymentType {
   static const displays = {
-    PaymentType.deposit: "Deposit Bitcoin",
-    PaymentType.withdraw: "Withdraw Bitcoin",
+    PaymentType.deposit: "Bitcoin Deposited",
+    PaymentType.withdraw: "Bitcoin Withdrawn",
     PaymentType.channelOpen: "Channel Opened",
     PaymentType.channelClose: "Channel Closed",
     PaymentType.send: "Payment Sent",

--- a/lib/models/payment.model.dart
+++ b/lib/models/payment.model.dart
@@ -43,5 +43,20 @@ extension PaymentTypeExtension on PaymentType {
     PaymentType.sportsbetClose: "Sports Bet Ended",
   };
 
+  static const displayBitcoin = {
+    PaymentType.deposit: true,
+    PaymentType.withdraw: true,
+    PaymentType.channelOpen: true,
+    PaymentType.channelClose: true,
+    PaymentType.send: false,
+    PaymentType.receive: false,
+    PaymentType.cfdOpen: false,
+    PaymentType.cfdClose: false,
+    PaymentType.sportsbetOpen: false,
+    PaymentType.sportsbetClose: false,
+  };
+
   String get display => displays[this]!;
+
+  bool isBitcoin() => displayBitcoin[this]!;
 }

--- a/lib/payment_history_change_notifier.dart
+++ b/lib/payment_history_change_notifier.dart
@@ -1,0 +1,15 @@
+import 'package:flutter/material.dart';
+import 'models/payment.model.dart';
+
+class PaymentHistory extends ChangeNotifier {
+  List<PaymentHistoryItem> history = List.empty();
+
+  void update(List<PaymentHistoryItem> history) {
+    this.history = history;
+    super.notifyListeners();
+  }
+
+  List<PaymentHistoryItem> bitcoinHistory() {
+    return history.where((element) => element.type.isBitcoin()).toList();
+  }
+}

--- a/lib/wallet/payment_history_list_item.dart
+++ b/lib/wallet/payment_history_list_item.dart
@@ -4,7 +4,7 @@ import '../models/payment.model.dart';
 
 @immutable
 class PaymentHistoryListItem extends StatelessWidget {
-  final PaymentHistoryItemItem data;
+  final PaymentHistoryItem data;
 
   const PaymentHistoryListItem({
     super.key,

--- a/lib/wallet/wallet_bitcoin.dart
+++ b/lib/wallet/wallet_bitcoin.dart
@@ -1,12 +1,13 @@
 import 'package:flutter/material.dart' hide Divider;
 import 'package:go_router/go_router.dart';
+import 'package:provider/provider.dart';
 import 'package:ten_ten_one/balance.dart';
-import 'package:ten_ten_one/mocks/payment_history.dart';
 import 'package:ten_ten_one/wallet/payment_history_list_item.dart';
 import 'package:ten_ten_one/utilities/divider.dart';
 import 'package:flutter_speed_dial/flutter_speed_dial.dart';
 import 'package:ten_ten_one/wallet/withdraw.dart';
 
+import '../payment_history_change_notifier.dart';
 import 'deposit.dart';
 
 class WalletBitcoin extends StatefulWidget {
@@ -24,20 +25,20 @@ class _WalletBitcoinState extends State<WalletBitcoin> {
 
   @override
   Widget build(BuildContext context) {
+    final history = context.watch<PaymentHistory>();
+
     List<Widget> widgets = [
       const Balance(balanceSelector: BalanceSelector.bitcoin),
       const Divider(),
     ];
 
-    final history = mockPaymentHistoryBitcoin(2);
-
     final txHistoryList = ListView.builder(
       shrinkWrap: true,
       physics: const ClampingScrollPhysics(),
       padding: const EdgeInsets.symmetric(vertical: 8.0),
-      itemCount: history.length,
+      itemCount: history.bitcoinHistory().length,
       itemBuilder: (context, index) {
-        return PaymentHistoryListItem(data: history[index]);
+        return PaymentHistoryListItem(data: history.bitcoinHistory()[index]);
       },
     );
 

--- a/lib/wallet/wallet_dashboard.dart
+++ b/lib/wallet/wallet_dashboard.dart
@@ -6,13 +6,13 @@ import 'package:ten_ten_one/cfd_trading/cfd_trading.dart';
 import 'package:ten_ten_one/models/balance_model.dart';
 import 'package:ten_ten_one/models/seed_backup_model.dart';
 import 'package:ten_ten_one/models/service_model.dart';
+import 'package:ten_ten_one/payment_history_change_notifier.dart';
 import 'package:ten_ten_one/wallet/deposit.dart';
 import 'package:ten_ten_one/wallet/payment_history_list_item.dart';
 import 'package:ten_ten_one/wallet/seed.dart';
 import 'package:ten_ten_one/wallet/service_card.dart';
 import 'package:ten_ten_one/utilities/divider.dart';
 
-import '../mocks/payment_history.dart';
 import 'open_channel.dart';
 
 class WalletDashboard extends StatefulWidget {
@@ -33,6 +33,7 @@ class _WalletDashboardState extends State<WalletDashboard> {
     final seedBackupModel = context.watch<SeedBackupModel>();
     final bitcoinBalance = context.watch<BitcoinBalance>();
     final lightningBalance = context.watch<LightningBalance>();
+    final paymentHistory = context.watch<PaymentHistory>();
 
     List<Widget> widgets = [
       const Balance(balanceSelector: BalanceSelector.both),
@@ -53,15 +54,13 @@ class _WalletDashboardState extends State<WalletDashboard> {
       widgets.add(const OpenChannelCard());
     }
 
-    final paymentHistory = mockPaymentHistory(10);
-
     final paymentHistoryList = ListView.builder(
       shrinkWrap: true,
       physics: const ClampingScrollPhysics(),
       padding: const EdgeInsets.symmetric(vertical: 8.0),
-      itemCount: paymentHistory.length,
+      itemCount: paymentHistory.history.length,
       itemBuilder: (context, index) {
-        return PaymentHistoryListItem(data: paymentHistory[index]);
+        return PaymentHistoryListItem(data: paymentHistory.history[index]);
       },
     );
 

--- a/rust/src/wallet.rs
+++ b/rust/src/wallet.rs
@@ -105,6 +105,16 @@ impl Wallet {
     pub async fn run_ldk(&self, listening_port: u16) -> Result<()> {
         lightning::run_ldk(&self.lightning, listening_port).await
     }
+
+    pub fn get_bitcoin_tx_history(&self) -> Result<Vec<bdk::TransactionDetails>> {
+        let tx_history = self
+            .lightning
+            .wallet
+            .get_wallet()
+            .list_transactions(false)?;
+        tracing::debug!(?tx_history, "Transaction history");
+        Ok(tx_history)
+    }
 }
 
 fn get_wallet() -> Result<MutexGuard<'static, Wallet>> {
@@ -135,6 +145,10 @@ pub fn get_balance() -> Result<bdk::Balance> {
 
 pub fn get_address() -> Result<bitcoin::Address> {
     get_wallet()?.get_address()
+}
+
+pub fn get_bitcoin_tx_history() -> Result<Vec<bdk::TransactionDetails>> {
+    get_wallet()?.get_bitcoin_tx_history()
 }
 
 pub fn get_seed_phrase() -> Result<Vec<String>> {


### PR DESCRIPTION
first part of https://github.com/itchysats/10101/issues/165

Given that this is independent of the Lightning payments (to some extent), it would be great if we can merge this already :)

--- 
Bitcoin history screenshots:

![image](https://user-images.githubusercontent.com/5557790/201581568-43a79813-7ddb-4d97-b54e-b96434609acf.png)

![image](https://user-images.githubusercontent.com/5557790/201581603-0ace60d3-242b-438b-8c55-e79bb9172356.png)

