### PR TITLE
Fetch bid ask index price from bitmex

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -82,6 +82,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "arrayvec"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8da52d66c7071e2e3fa2a1e5c6d088fec47b593032b254f5e980de8ea54454d6"
+
+[[package]]
 name = "async-stream"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -285,6 +291,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
+name = "bitmex-stream"
+version = "0.1.1"
+source = "git+https://github.com/itchysats/itchysats?rev=8f935e9dfc704b12eb6c98abd873db30dd39aece#8f935e9dfc704b12eb6c98abd873db30dd39aece"
+dependencies = [
+ "anyhow",
+ "async-stream",
+ "futures",
+ "hex",
+ "ring",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tokio-tungstenite",
+ "tracing",
+]
+
+[[package]]
+name = "block-buffer"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "block-buffer"
 version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -411,6 +443,16 @@ dependencies = [
  "subtle",
  "time 0.3.17",
  "version_check",
+]
+
+[[package]]
+name = "core-foundation"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "194a7a9e6de53fa55116934067c844d9d749312f75c6f6d0980e8c252f8c2146"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -558,11 +600,20 @@ dependencies = [
 
 [[package]]
 name = "digest"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
+name = "digest"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "adfbc57365a37acbd2ebf2b64d7e69bb766e2fea813521ed536f5d0520dcf86c"
 dependencies = [
- "block-buffer",
+ "block-buffer 0.10.3",
  "crypto-common",
  "subtle",
 ]
@@ -583,11 +634,11 @@ dependencies = [
  "byteorder",
  "libc",
  "log",
- "rustls",
+ "rustls 0.20.7",
  "serde",
  "serde_json",
- "webpki",
- "webpki-roots",
+ "webpki 0.22.0",
+ "webpki-roots 0.22.5",
  "winapi",
 ]
 
@@ -655,6 +706,15 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "form_urlencoded"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9c384f161156f5260c24a097c56119f9be8c798586aecc13afbcbe7b7e26bf8"
+dependencies = [
+ "percent-encoding",
+]
 
 [[package]]
 name = "fs2"
@@ -852,6 +912,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
+name = "heck"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2540771e65fc8cb83cd6e8a237f70c319bd5c29f78ed1084ba5d50eeac86f7f9"
+
+[[package]]
 name = "hermit-abi"
 version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -859,6 +925,12 @@ checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hkdf"
@@ -875,7 +947,7 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
- "digest",
+ "digest 0.10.5",
 ]
 
 [[package]]
@@ -970,6 +1042,17 @@ checksum = "0703ae284fc167426161c2e3f1da3ea71d94b21bedbcc9494e92b28e334e3dca"
 dependencies = [
  "cxx",
  "cxx-build",
+]
+
+[[package]]
+name = "idna"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de910d521f7cc3135c4de8db1cb910e0b5ed1dc6f57c381cd07e8e661ce10094"
+dependencies = [
+ "matches",
+ "unicode-bidi",
+ "unicode-normalization",
 ]
 
 [[package]]
@@ -1158,9 +1241,16 @@ dependencies = [
  "anyhow",
  "atty",
  "bdk",
+ "bitmex-stream",
+ "futures",
  "http-api-problem",
  "rocket",
+ "rust_decimal",
+ "rust_decimal_macros",
  "serde",
+ "serde_json",
+ "strum",
+ "strum_macros",
  "ten_ten_one",
  "time 0.3.17",
  "tokio",
@@ -1176,6 +1266,12 @@ checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
 dependencies = [
  "regex-automata",
 ]
+
+[[package]]
+name = "matches"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3e378b66a060d48947b590737b30a1be76706c8dd7b8ba0f2fe3989c68a853f"
 
 [[package]]
 name = "maybe-uninit"
@@ -1232,7 +1328,7 @@ dependencies = [
  "libc",
  "log",
  "wasi 0.11.0+wasi-snapshot-preview1",
- "windows-sys",
+ "windows-sys 0.42.0",
 ]
 
 [[package]]
@@ -1316,6 +1412,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
+name = "openssl-probe"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
+
+[[package]]
 name = "overload"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1366,7 +1468,7 @@ dependencies = [
  "libc",
  "redox_syscall",
  "smallvec 1.10.0",
- "windows-sys",
+ "windows-sys 0.42.0",
 ]
 
 [[package]]
@@ -1397,6 +1499,26 @@ name = "percent-encoding"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "478c572c3d73181ff3c2539045f6eb99e5491218eae919370993b890cdbdd98e"
+
+[[package]]
+name = "pin-project"
+version = "1.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad29a609b6bcd67fee905812e544992d216af9d755757c05ed2d0e15a74c6ecc"
+dependencies = [
+ "pin-project-internal",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "1.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "069bdb1e05adc7a8990dce9cc75370895fbe4e3d58b9b73bf1aee56359344a55"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "pin-project-lite"
@@ -1766,10 +1888,44 @@ dependencies = [
 ]
 
 [[package]]
+name = "rust_decimal"
+version = "1.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee9164faf726e4f3ece4978b25ca877ddc6802fa77f38cdccb32c7f805ecd70c"
+dependencies = [
+ "arrayvec",
+ "num-traits",
+ "serde",
+]
+
+[[package]]
+name = "rust_decimal_macros"
+version = "1.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4903d8db81d2321699ca8318035d6ff805c548868df435813968795a802171b2"
+dependencies = [
+ "quote",
+ "rust_decimal",
+]
+
+[[package]]
 name = "rustc-demangle"
 version = "0.1.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ef03e0a2b150c7a90d01faf6254c9c48a41e95fb2a8c2ac1c6f0d2b9aefc342"
+
+[[package]]
+name = "rustls"
+version = "0.19.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35edb675feee39aec9c99fa5ff985081995a06d594114ae14cbe797ad7b7a6d7"
+dependencies = [
+ "base64",
+ "log",
+ "ring",
+ "sct 0.6.1",
+ "webpki 0.21.4",
+]
 
 [[package]]
 name = "rustls"
@@ -1779,8 +1935,20 @@ checksum = "539a2bfe908f471bfa933876bd1eb6a19cf2176d375f82ef7f99530a40e48c2c"
 dependencies = [
  "log",
  "ring",
- "sct",
- "webpki",
+ "sct 0.7.0",
+ "webpki 0.22.0",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a07b7c1885bd8ed3831c289b7870b13ef46fe0e856d288c30d9cc17d75a2092"
+dependencies = [
+ "openssl-probe",
+ "rustls 0.19.1",
+ "schannel",
+ "security-framework",
 ]
 
 [[package]]
@@ -1794,6 +1962,16 @@ name = "ryu"
 version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4501abdff3ae82a1c1b477a17252eb69cee9e66eb915c1abaa4f44d873df9f09"
+
+[[package]]
+name = "schannel"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88d6731146462ea25d9244b2ed5fd1d716d25c52e4d54aa4fb0f3c4e9854dbe2"
+dependencies = [
+ "lazy_static",
+ "windows-sys 0.36.1",
+]
 
 [[package]]
 name = "scoped-tls"
@@ -1812,6 +1990,16 @@ name = "scratch"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8132065adcfd6e02db789d9285a0deb2f3fcb04002865ab67d5fb103533898"
+
+[[package]]
+name = "sct"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b362b83898e0e69f38515b82ee15aa80636befe47c3b6d3d89a911e78fc228ce"
+dependencies = [
+ "ring",
+ "untrusted",
+]
 
 [[package]]
 name = "sct"
@@ -1842,6 +2030,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83080e2c2fc1006e625be82e5d1eb6a43b7fd9578b617fcc55814daf286bba4b"
 dependencies = [
  "cc",
+]
+
+[[package]]
+name = "security-framework"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bc1bb97804af6631813c55739f771071e0f2ed33ee20b68c86ec505d906356c"
+dependencies = [
+ "bitflags",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0160a13a177a45bfb43ce71c01580998474f556ad854dcbca936dd2841a5c556"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -1876,6 +2087,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha-1"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99cd6713db3cf16b6c84e06321e049a9b9f699826e16096d23bbcc44d15d51a6"
+dependencies = [
+ "block-buffer 0.9.0",
+ "cfg-if",
+ "cpufeatures",
+ "digest 0.9.0",
+ "opaque-debug",
+]
+
+[[package]]
 name = "sha2"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1883,7 +2107,7 @@ checksum = "82e6b795fe2e3b1e845bafcb27aa35405c4d47cdfc92af5fc8d3002f76cebdc0"
 dependencies = [
  "cfg-if",
  "cpufeatures",
- "digest",
+ "digest 0.10.5",
 ]
 
 [[package]]
@@ -1985,6 +2209,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "strum"
+version = "0.24.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "063e6045c0e62079840579a7e47a355ae92f60eb74daaf156fb1e84ba164e63f"
+
+[[package]]
+name = "strum_macros"
+version = "0.24.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e385be0d24f186b4ce2f9982191e7101bb737312ad61c1f2f984f34bcf85d59"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn",
+]
+
+[[package]]
 name = "subtle"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2052,6 +2295,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bab24d30b911b2376f3a13cc2cd443142f0c81dda04c118693e35b3835757755"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "thiserror"
+version = "1.0.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10deb33631e3c9018b9baf9dcbbc4f737320d2b576bac10f6aefa048fa407e3e"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "982d17546b47146b28f7c22e3d08465f6b8903d0ea13c1660d9d84a6e7adcdbb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -2126,6 +2389,7 @@ dependencies = [
  "signal-hook-registry",
  "socket2",
  "tokio-macros",
+ "tracing",
  "winapi",
 ]
 
@@ -2141,6 +2405,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-rustls"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc6844de72e57df1980054b38be3a9f4702aba4858be64dd700181a8a6d0e1b6"
+dependencies = [
+ "rustls 0.19.1",
+ "tokio",
+ "webpki 0.21.4",
+]
+
+[[package]]
 name = "tokio-stream"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2149,6 +2424,23 @@ dependencies = [
  "futures-core",
  "pin-project-lite",
  "tokio",
+]
+
+[[package]]
+name = "tokio-tungstenite"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "511de3f85caf1c98983545490c3d09685fa8eb634e57eec22bb4db271f46cbd8"
+dependencies = [
+ "futures-util",
+ "log",
+ "pin-project",
+ "rustls 0.19.1",
+ "tokio",
+ "tokio-rustls",
+ "tungstenite",
+ "webpki 0.21.4",
+ "webpki-roots 0.21.1",
 ]
 
 [[package]]
@@ -2263,6 +2555,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59547bce71d9c38b83d9c0e92b6066c4253371f15005def0c30d9657f50c7642"
 
 [[package]]
+name = "tungstenite"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0b2d8558abd2e276b0a8df5c05a2ec762609344191e5fd23e292c910e9165b5"
+dependencies = [
+ "base64",
+ "byteorder",
+ "bytes",
+ "http",
+ "httparse",
+ "log",
+ "rand 0.8.5",
+ "rustls 0.19.1",
+ "rustls-native-certs",
+ "sha-1",
+ "thiserror",
+ "url",
+ "utf-8",
+ "webpki 0.21.4",
+]
+
+[[package]]
 name = "typenum"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2286,6 +2600,12 @@ dependencies = [
  "serde",
  "version_check",
 ]
+
+[[package]]
+name = "unicode-bidi"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "099b7128301d285f79ddd55b9a83d5e6b9e97c92e0ea0daebee7263e932de992"
 
 [[package]]
 name = "unicode-ident"
@@ -2329,6 +2649,23 @@ name = "untrusted"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
+
+[[package]]
+name = "url"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22fe195a4f217c25b25cb5058ced57059824a678474874038dc88d211bf508d3"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "percent-encoding",
+]
+
+[[package]]
+name = "utf-8"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
 
 [[package]]
 name = "uuid"
@@ -2439,6 +2776,16 @@ dependencies = [
 
 [[package]]
 name = "webpki"
+version = "0.21.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8e38c0608262c46d4a56202ebabdeb094cef7e560ca7a226c6bf055188aa4ea"
+dependencies = [
+ "ring",
+ "untrusted",
+]
+
+[[package]]
+name = "webpki"
 version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f095d78192e208183081cc07bc5515ef55216397af48b873e5edcd72637fa1bd"
@@ -2449,11 +2796,20 @@ dependencies = [
 
 [[package]]
 name = "webpki-roots"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aabe153544e473b775453675851ecc86863d2a81d786d741f6b76778f2a48940"
+dependencies = [
+ "webpki 0.21.4",
+]
+
+[[package]]
+name = "webpki-roots"
 version = "0.22.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "368bfe657969fb01238bb756d351dcade285e0f6fcbd36dcb23359a5169975be"
 dependencies = [
- "webpki",
+ "webpki 0.22.0",
 ]
 
 [[package]]
@@ -2502,6 +2858,19 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea04155a16a59f9eab786fe12a4a450e75cdb175f9e0d80da1e17db09f55b8d2"
+dependencies = [
+ "windows_aarch64_msvc 0.36.1",
+ "windows_i686_gnu 0.36.1",
+ "windows_i686_msvc 0.36.1",
+ "windows_x86_64_gnu 0.36.1",
+ "windows_x86_64_msvc 0.36.1",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a3e1820f08b8513f676f7ab6c1f99ff312fb97b553d30ff4dd86f9f15728aa7"
@@ -2529,6 +2898,12 @@ checksum = "d8e92753b1c443191654ec532f14c199742964a061be25d77d7a96f09db20bf5"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9bb8c3fd39ade2d67e9874ac4f3db21f0d710bee00fe7cab16949ec184eeaa47"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd0f252f5a35cac83d6311b2e795981f5ee6e67eb1f9a7f64eb4500fbc4dcdb4"
@@ -2538,6 +2913,12 @@ name = "windows_i686_gnu"
 version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a711c68811799e017b6038e0922cb27a5e2f43a2ddb609fe0b6f3eeda9de615"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "180e6ccf01daf4c426b846dfc66db1fc518f074baa793aa7d9b9aaeffad6a3b6"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -2553,6 +2934,12 @@ checksum = "146c11bb1a02615db74680b32a68e2d61f553cc24c4eb5b4ca10311740e44172"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2e7917148b2812d1eeafaeb22a97e4813dfa60a3f8f78ebe204bcc88f12f024"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "84c12f65daa39dd2babe6e442988fc329d6243fdce47d7d2d155b8d874862246"
@@ -2562,6 +2949,12 @@ name = "windows_x86_64_gnu"
 version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c912b12f7454c6620635bbff3450962753834be2a594819bd5e945af18ec64bc"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4dcd171b8776c41b97521e5da127a2d86ad280114807d0b2ab1e462bc764d9e1"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -2580,6 +2973,12 @@ name = "windows_x86_64_msvc"
 version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "504a2476202769977a040c6364301a3f65d0cc9e3fb08600b2bda150a0488316"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c811ca4a8c853ef420abd8592ba53ddbbac90410fab6903b3e79972a631f7680"
 
 [[package]]
 name = "windows_x86_64_msvc"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -292,8 +292,8 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitmex-stream"
-version = "0.1.1"
-source = "git+https://github.com/itchysats/itchysats?rev=8f935e9dfc704b12eb6c98abd873db30dd39aece#8f935e9dfc704b12eb6c98abd873db30dd39aece"
+version = "0.1.0"
+source = "git+https://github.com/itchysats/itchysats?rev=6e4998ceeb3e21c641da209edd5cd592dbab6802#6e4998ceeb3e21c641da209edd5cd592dbab6802"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -303,8 +303,10 @@ dependencies = [
  "serde",
  "serde_json",
  "tokio",
+ "tokio-extras",
  "tokio-tungstenite",
  "tracing",
+ "url",
 ]
 
 [[package]]
@@ -2473,6 +2475,17 @@ dependencies = [
  "tokio-macros",
  "tracing",
  "winapi",
+]
+
+[[package]]
+name = "tokio-extras"
+version = "0.1.0"
+source = "git+https://github.com/itchysats/itchysats?rev=6e4998ceeb3e21c641da209edd5cd592dbab6802#6e4998ceeb3e21c641da209edd5cd592dbab6802"
+dependencies = [
+ "futures",
+ "pin-project-lite",
+ "tokio",
+ "tracing",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1021,6 +1021,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper-rustls"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d87c48c02e0dc5e3b849a2041db3029fd066650f8f717c07bf8ed78ccb895cac"
+dependencies = [
+ "http",
+ "hyper",
+ "rustls 0.20.7",
+ "tokio",
+ "tokio-rustls 0.23.4",
+]
+
+[[package]]
 name = "iana-time-zone"
 version = "0.1.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1089,6 +1102,12 @@ checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
 dependencies = [
  "cfg-if",
 ]
+
+[[package]]
+name = "ipnet"
+version = "2.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f88c5561171189e69df9d98bcf18fd5f9558300f7ea7b801eb8a0fd748bd8745"
 
 [[package]]
 name = "itoa"
@@ -1789,6 +1808,45 @@ dependencies = [
 ]
 
 [[package]]
+name = "reqwest"
+version = "0.11.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "431949c384f4e2ae07605ccaa56d1d9d2ecdb5cadd4f9577ccfab29f2e5149fc"
+dependencies = [
+ "base64",
+ "bytes",
+ "encoding_rs",
+ "futures-core",
+ "futures-util",
+ "h2",
+ "http",
+ "http-body",
+ "hyper",
+ "hyper-rustls",
+ "ipnet",
+ "js-sys",
+ "log",
+ "mime",
+ "once_cell",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustls 0.20.7",
+ "rustls-pemfile",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "tokio",
+ "tokio-rustls 0.23.4",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "webpki-roots 0.22.5",
+ "winreg",
+]
+
+[[package]]
 name = "ring"
 version = "0.16.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1952,6 +2010,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls-pemfile"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0864aeff53f8c05aa08d86e5ef839d3dfcf07aeba2db32f12db0ef716e87bd55"
+dependencies = [
+ "base64",
+]
+
+[[package]]
 name = "rustversion"
 version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2081,6 +2148,18 @@ version = "1.0.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce777b7b150d76b9cf60d28b55f5847135a003f7d7350c6be7a773508ce7d45"
 dependencies = [
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
  "itoa",
  "ryu",
  "serde",
@@ -2280,6 +2359,9 @@ dependencies = [
  "lightning-persister",
  "lightning-rapid-gossip-sync",
  "rand 0.6.5",
+ "reqwest",
+ "rust_decimal",
+ "serde",
  "sha2",
  "state",
  "time 0.3.17",
@@ -2416,6 +2498,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-rustls"
+version = "0.23.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c43ee83903113e03984cb9e5cebe6c04a5116269e900e3ddba8f068a62adda59"
+dependencies = [
+ "rustls 0.20.7",
+ "tokio",
+ "webpki 0.22.0",
+]
+
+[[package]]
 name = "tokio-stream"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2437,7 +2530,7 @@ dependencies = [
  "pin-project",
  "rustls 0.19.1",
  "tokio",
- "tokio-rustls",
+ "tokio-rustls 0.22.0",
  "tungstenite",
  "webpki 0.21.4",
  "webpki-roots 0.21.1",
@@ -2736,6 +2829,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23639446165ca5a5de86ae1d8896b737ae80319560fbaa4c2887b7da6e7ebd7d"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
 name = "wasm-bindgen-macro"
 version = "0.2.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2985,6 +3090,15 @@ name = "windows_x86_64_msvc"
 version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f40009d85759725a34da6d89a94e63d7bdc50a862acf0dbc7c8e488f1edcb6f5"
+
+[[package]]
+name = "winreg"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80d0f4e272c85def139476380b12f9ac60926689dd2e01d4923222f40580869d"
+dependencies = [
+ "winapi",
+]
 
 [[package]]
 name = "yansi"

--- a/lib/cfd_trading/cfd_offer.dart
+++ b/lib/cfd_trading/cfd_offer.dart
@@ -5,6 +5,7 @@ import 'package:go_router/go_router.dart';
 import 'package:intl/intl.dart';
 import 'package:provider/provider.dart';
 import 'package:ten_ten_one/balance.dart';
+import 'package:ten_ten_one/cfd_trading/cfd_offer_change_notifier.dart';
 import 'package:ten_ten_one/cfd_trading/cfd_order_confirmation.dart';
 import 'package:ten_ten_one/cfd_trading/cfd_trading.dart';
 import 'package:ten_ten_one/cfd_trading/cfd_trading_change_notifier.dart';
@@ -32,6 +33,7 @@ class _CfdOfferState extends State<CfdOffer> {
     final formatter = NumberFormat.decimalPattern('en');
 
     final cfdTradingService = context.watch<CfdTradingChangeNotifier>();
+    final cfdOffersChangeNotifer = context.watch<CfdOfferChangeNotifier>();
 
     // mock data
     cfdTradingService.draftOrder ??= Order(
@@ -46,18 +48,19 @@ class _CfdOfferState extends State<CfdOffer> {
 
     order = cfdTradingService.draftOrder!;
 
-    // mock data
-    const bid = 19000;
-    const ask = 19200;
-    const index = 19100;
+    final liquidationPrice = formatter.format(order.liquidationPrice);
+    final fundingRate = order.fundingRate.display(currency: Currency.btc).value;
+    final margin = order.margin.display(currency: Currency.btc).value;
+
+    final offer = cfdOffersChangeNotifer.offer!;
+
+    final bid = offer.bid;
+    final ask = offer.ask;
+    final index = offer.index;
 
     final fmtBid = formatter.format(bid);
     final fmtAsk = formatter.format(ask);
     final fmtIndex = formatter.format(index);
-
-    final liquidationPrice = formatter.format(order.liquidationPrice);
-    final fundingRate = order.fundingRate.display(currency: Currency.btc).value;
-    final margin = order.margin.display(currency: Currency.btc).value;
 
     return Scaffold(
       body: ListView(padding: const EdgeInsets.only(left: 25, right: 25), children: [
@@ -74,7 +77,9 @@ class _CfdOfferState extends State<CfdOffer> {
         const SizedBox(height: 30),
         PositionSelection(
             onChange: (position) {
-              order.position = position!;
+              setState(() {
+                order.position = position!;
+              });
             },
             value: order.position),
         const SizedBox(height: 15),

--- a/lib/cfd_trading/cfd_offer_change_notifier.dart
+++ b/lib/cfd_trading/cfd_offer_change_notifier.dart
@@ -1,0 +1,11 @@
+import 'package:flutter/material.dart';
+import 'package:ten_ten_one/bridge_generated/bridge_definitions.dart';
+
+class CfdOfferChangeNotifier extends ChangeNotifier {
+  Offer? offer;
+
+  void update(Offer offer) async {
+    this.offer = offer;
+    super.notifyListeners();
+  }
+}

--- a/maker/Cargo.toml
+++ b/maker/Cargo.toml
@@ -8,9 +8,9 @@ edition = "2021"
 [dependencies]
 anyhow = { version = "1", features = ["backtrace"] }
 atty = "0.2.14"
+bdk = "0.24.0"
 bitmex-stream = { git = "https://github.com/itchysats/itchysats", rev = "8f935e9dfc704b12eb6c98abd873db30dd39aece" }
 futures = "0.3"
-bdk = "0.24.0"
 http-api-problem = { version = "0.55.0", features = ["rocket"] }
 rocket = { version = "0.5.0-rc.2", features = ["json", "uuid"] }
 rust_decimal = { version = "1", features = ["serde-with-float"] }

--- a/maker/Cargo.toml
+++ b/maker/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2021"
 anyhow = { version = "1", features = ["backtrace"] }
 atty = "0.2.14"
 bdk = "0.24.0"
-bitmex-stream = { git = "https://github.com/itchysats/itchysats", rev = "8f935e9dfc704b12eb6c98abd873db30dd39aece" }
+bitmex-stream = { git = "https://github.com/itchysats/itchysats", rev = "6e4998ceeb3e21c641da209edd5cd592dbab6802" }
 futures = "0.3"
 http-api-problem = { version = "0.55.0", features = ["rocket"] }
 rocket = { version = "0.5.0-rc.2", features = ["json", "uuid"] }

--- a/maker/Cargo.toml
+++ b/maker/Cargo.toml
@@ -8,12 +8,22 @@ edition = "2021"
 [dependencies]
 anyhow = { version = "1", features = ["backtrace"] }
 atty = "0.2.14"
+bitmex-stream = { git = "https://github.com/itchysats/itchysats", rev = "8f935e9dfc704b12eb6c98abd873db30dd39aece" }
+futures = "0.3"
 bdk = "0.24.0"
 http-api-problem = { version = "0.55.0", features = ["rocket"] }
 rocket = { version = "0.5.0-rc.2", features = ["json", "uuid"] }
+rust_decimal = { version = "1", features = ["serde-with-float"] }
+rust_decimal_macros = "1"
 serde = "1.0.147"
+serde_json = { version = "1", features = ["raw_value"] }
+strum = "0.24"
+strum_macros = "0.24"
 ten_ten_one = { version = "0.1.0", path = "../rust" }
 time = { version = "0.3", features = ["serde", "parsing", "std", "formatting", "macros", "serde-well-known"] }
 tokio = { version = "1", features = ["io-util", "macros", "rt", "rt-multi-thread", "sync", "net", "time"] }
 tracing = "0.1.37"
 tracing-subscriber = { version = "0.3", default-features = false, features = ["fmt", "ansi", "env-filter", "time", "tracing-log", "json"] }
+
+[dev-dependencies]
+rust_decimal_macros = "1"

--- a/maker/src/bitmex.rs
+++ b/maker/src/bitmex.rs
@@ -1,0 +1,162 @@
+use anyhow::Result;
+use futures::TryStreamExt;
+use rust_decimal::Decimal;
+use std::str::FromStr;
+use time::OffsetDateTime;
+use tokio::sync::watch;
+use tokio::task::JoinHandle;
+
+pub const QUOTE_INTERVAL_MINUTES: i64 = 1;
+
+pub fn subscribe() -> Result<(JoinHandle<()>, watch::Receiver<Option<Quote>>)> {
+    let (quote_sender, quote_receiver) = watch::channel(None);
+
+    let handle = tokio::spawn(async move {
+        let mut stream = bitmex_stream::subscribe(
+            ["instrument:XBTUSD".to_string()],
+            bitmex_stream::Network::Testnet,
+        );
+
+        while let Some(text) = stream.try_next().await.expect("message from bitmex") {
+            tracing::trace!(%text, "Received message from bitmex");
+            let quote = Quote::from_str(&text).expect("quote from bitmex");
+            if let Some(quote) = quote {
+                tracing::debug!(
+                    "Received quote update for {:?}, bid: {}, ask: {}, index: {}, timestamp: {}",
+                    quote.symbol,
+                    quote.bid,
+                    quote.ask,
+                    quote.index,
+                    quote.timestamp
+                );
+                let _ = quote_sender.send(Some(quote));
+            }
+        }
+    });
+    Ok((handle, quote_receiver))
+}
+
+#[derive(Clone, Copy)]
+pub struct Quote {
+    pub timestamp: OffsetDateTime,
+    pub bid: Decimal,
+    pub ask: Decimal,
+    pub index: Decimal,
+    pub symbol: ContractSymbol,
+}
+
+#[derive(
+    Debug, Clone, Copy, strum_macros::EnumString, strum_macros::Display, PartialEq, Eq, Hash,
+)]
+pub enum ContractSymbol {
+    #[strum(serialize = "XBTUSD")]
+    BtcUsd,
+}
+
+impl Quote {
+    fn from_str(text: &str) -> Result<Option<Self>> {
+        let table_message = match serde_json::from_str::<wire::TableMessage>(text) {
+            Ok(table_message) => table_message,
+            Err(e) => {
+                tracing::trace!(%text, %e, "Not a 'table' message, skipping...");
+                return Ok(None);
+            }
+        };
+
+        let [quote] = table_message.data;
+
+        let symbol = ContractSymbol::from_str(quote.symbol.as_str())?;
+        Ok(Some(Self {
+            timestamp: quote.timestamp,
+            bid: quote.bid_price,
+            ask: quote.ask_price,
+            index: quote.mark_price,
+            symbol,
+        }))
+    }
+
+    pub fn bid(&self) -> Decimal {
+        self.bid
+    }
+
+    pub fn ask(&self) -> Decimal {
+        self.ask
+    }
+
+    pub fn is_older_than(&self, duration: time::Duration) -> bool {
+        let required_quote_timestamp = (OffsetDateTime::now_utc() - duration).unix_timestamp();
+
+        self.timestamp.unix_timestamp() < required_quote_timestamp
+    }
+}
+
+mod wire {
+    use super::*;
+    use serde::Deserialize;
+
+    #[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
+    pub struct TableMessage {
+        pub table: String,
+        // we always just expect a single quote, hence the use of an array instead of a vec
+        pub data: [QuoteData; 1],
+    }
+
+    #[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
+    #[serde(rename_all = "camelCase")]
+    pub struct QuoteData {
+        #[serde(with = "rust_decimal::serde::float")]
+        pub bid_price: Decimal,
+        #[serde(with = "rust_decimal::serde::float")]
+        pub ask_price: Decimal,
+        #[serde(with = "rust_decimal::serde::float")]
+        pub mark_price: Decimal,
+        pub symbol: String,
+        #[serde(with = "time::serde::rfc3339")]
+        pub timestamp: OffsetDateTime,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rust_decimal_macros::dec;
+    use time::ext::NumericalDuration;
+
+    #[test]
+    fn can_deserialize_quote_message() {
+        let quote = Quote::from_str(r#"{"table":"quoteBin1m","action":"insert","data":[{"timestamp":"2021-09-21T02:40:00.000Z","symbol":"XBTUSD","bidSize":50200,"bidPrice":42640.5,"askPrice":42641,"markPrice":42641,"askSize":363600}]}"#).unwrap().unwrap();
+
+        assert_eq!(quote.bid, dec!(42640.5));
+        assert_eq!(quote.ask, dec!(42641));
+        assert_eq!(quote.timestamp.unix_timestamp(), 1632192000);
+        assert_eq!(quote.symbol, ContractSymbol::BtcUsd)
+    }
+
+    #[test]
+    fn quote_from_now_is_not_old() {
+        let quote = dummy_quote_at(OffsetDateTime::now_utc());
+
+        let is_older = quote.is_older_than(1.minutes());
+
+        assert!(!is_older)
+    }
+
+    #[test]
+    fn quote_from_one_hour_ago_is_old() {
+        let quote = dummy_quote_at(OffsetDateTime::now_utc() - 1.hours());
+
+        let is_older = quote.is_older_than(1.minutes());
+
+        assert!(is_older)
+    }
+
+    fn dummy_quote_at(timestamp: OffsetDateTime) -> Quote {
+        Quote {
+            timestamp,
+            bid: dec!(10),
+            ask: dec!(10),
+            symbol: ContractSymbol::BtcUsd,
+            index: dec!(10),
+        }
+    }
+}

--- a/maker/src/lib.rs
+++ b/maker/src/lib.rs
@@ -1,2 +1,3 @@
+pub mod bitmex;
 pub mod logger;
 pub mod routes;

--- a/maker/src/main.rs
+++ b/maker/src/main.rs
@@ -1,4 +1,5 @@
 use anyhow::Result;
+use maker::bitmex;
 use maker::logger;
 use maker::routes;
 use std::env::current_dir;
@@ -17,7 +18,7 @@ async fn main() -> Result<()> {
     tokio::spawn(async move {
         let (_tcp_handle, _background_processor) = wallet::run_ldk_server(port)
             .await
-            .expect("lightning network to run");
+            .expect("lightning node to run");
 
         let public_key = wallet::node_id().expect("To get node id for maker");
         let listening_address = format!("{public_key}@127.0.0.1:{port}");
@@ -36,11 +37,14 @@ async fn main() -> Result<()> {
         }
     });
 
+    let (_, quote_receiver) = bitmex::subscribe()?;
+
     let mission_success = rocket::build()
         .mount(
             "/api",
             rocket::routes![routes::get_offers, routes::post_force_close_channel],
         )
+        .manage(quote_receiver)
         .launch()
         .await?;
 

--- a/maker/src/main.rs
+++ b/maker/src/main.rs
@@ -42,7 +42,7 @@ async fn main() -> Result<()> {
     let mission_success = rocket::build()
         .mount(
             "/api",
-            rocket::routes![routes::get_offers, routes::post_force_close_channel],
+            rocket::routes![routes::get_offer, routes::post_force_close_channel],
         )
         .manage(quote_receiver)
         .launch()

--- a/maker/src/routes.rs
+++ b/maker/src/routes.rs
@@ -8,8 +8,8 @@ use rocket::serde::Serialize;
 use rocket::State;
 use rust_decimal::Decimal;
 use rust_decimal_macros::dec;
-use tokio::sync::watch;
 use ten_ten_one::wallet::force_close_channel;
+use tokio::sync::watch;
 
 #[derive(Serialize, Deserialize, Debug)]
 pub struct Offer {

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -26,6 +26,9 @@ lightning-net-tokio = { version = "0.0.112" }
 lightning-persister = { version = "0.0.112" }
 lightning-rapid-gossip-sync = { version = "0.0.112" }
 rand = "^0.6.0"
+reqwest = { version = "0.11", default-features = false, features = ["json", "rustls-tls-webpki-roots"] }
+rust_decimal = { version = "1", features = ["serde-with-float"] }
+serde = "1.0.147"
 sha2 = "0.10"
 state = "0.5.3"
 time = { version = "0.3", features = ["serde", "parsing", "std", "formatting", "macros", "serde-well-known"] }

--- a/rust/src/api.rs
+++ b/rust/src/api.rs
@@ -1,5 +1,7 @@
 use crate::disk::parse_peer_info;
 use crate::logger;
+use crate::offer;
+use crate::offer::Offer;
 use crate::wallet;
 use crate::wallet::Balance;
 use crate::wallet::Network;
@@ -91,6 +93,11 @@ pub async fn open_cfd(taker_amount: u64, leverage: u64) -> Result<()> {
     wallet::open_cfd(taker_amount, maker_amount).await?;
 
     Ok(())
+}
+
+pub fn get_offer() -> Result<Offer> {
+    let rt = Runtime::new()?;
+    rt.block_on(async { offer::get_offer().await })
 }
 
 pub fn get_bitcoin_tx_history() -> Result<Vec<BitcoinTxHistoryItem>> {

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -4,5 +4,6 @@ pub mod disk;
 mod hex_utils;
 pub mod lightning;
 pub mod logger;
+mod offer;
 pub mod seed;
 pub mod wallet;

--- a/rust/src/offer.rs
+++ b/rust/src/offer.rs
@@ -1,0 +1,22 @@
+use anyhow::anyhow;
+use anyhow::Result;
+
+use serde::Deserialize;
+use serde::Serialize;
+
+static MAKER_ENDPOINT: &str = "http://127.0.0.1:8000";
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct Offer {
+    pub bid: f64,
+    pub ask: f64,
+    pub index: f64,
+}
+
+pub async fn get_offer() -> Result<Offer> {
+    reqwest::get(format!("{}/api/offer", MAKER_ENDPOINT))
+        .await?
+        .json::<Offer>()
+        .await
+        .map_err(|e| anyhow!("Failed to fetch offer {e:?}"))
+}


### PR DESCRIPTION
@bonomat @da-kami Please check the spread calculation on the long and short offers. I tried to align with the logic I found in the maker automation, but I don't think I got it completely right.

- subscribes to the bitmex api for btxusd prices using the instrument target (as this is including bid, ask and index price in one message)
- skipped ethusd for now, as it would only introduce additional complexities which we don't need now.
- reused the bitmex-stream lib from itchysats
- wires offers to the cfd offer screen through periodical rust taker api calls.
- hide material app until ready

<img width="389" alt="Screenshot 2022-11-16 at 10 27 26" src="https://user-images.githubusercontent.com/382048/202142020-134e0f09-bf2b-4a91-94c8-304d36c0ccf9.png">

see commit messages for more details

resolves #106 