### PR TITLE
chore: bump ldk to fix persistance

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1037,7 +1037,7 @@ checksum = "fc7fcc620a3bff7cdd7a365be3376c97191aeaccc2a603e600951e452615bf89"
 [[package]]
 name = "lightning"
 version = "0.0.112"
-source = "git+https://github.com/itchysats/rust-lightning?rev=321848d0911928527ea5d94f88bcaa4587475ab3#321848d0911928527ea5d94f88bcaa4587475ab3"
+source = "git+https://github.com/itchysats/rust-lightning?rev=2a0edd5c4b012ab6b166ee1c5a68e6974b93dcb2#2a0edd5c4b012ab6b166ee1c5a68e6974b93dcb2"
 dependencies = [
  "bitcoin",
 ]
@@ -1045,7 +1045,7 @@ dependencies = [
 [[package]]
 name = "lightning-background-processor"
 version = "0.0.112"
-source = "git+https://github.com/itchysats/rust-lightning?rev=321848d0911928527ea5d94f88bcaa4587475ab3#321848d0911928527ea5d94f88bcaa4587475ab3"
+source = "git+https://github.com/itchysats/rust-lightning?rev=2a0edd5c4b012ab6b166ee1c5a68e6974b93dcb2#2a0edd5c4b012ab6b166ee1c5a68e6974b93dcb2"
 dependencies = [
  "bitcoin",
  "lightning",
@@ -1055,7 +1055,7 @@ dependencies = [
 [[package]]
 name = "lightning-block-sync"
 version = "0.0.112"
-source = "git+https://github.com/itchysats/rust-lightning?rev=321848d0911928527ea5d94f88bcaa4587475ab3#321848d0911928527ea5d94f88bcaa4587475ab3"
+source = "git+https://github.com/itchysats/rust-lightning?rev=2a0edd5c4b012ab6b166ee1c5a68e6974b93dcb2#2a0edd5c4b012ab6b166ee1c5a68e6974b93dcb2"
 dependencies = [
  "bitcoin",
  "chunked_transfer",
@@ -1068,7 +1068,7 @@ dependencies = [
 [[package]]
 name = "lightning-invoice"
 version = "0.20.0"
-source = "git+https://github.com/itchysats/rust-lightning?rev=321848d0911928527ea5d94f88bcaa4587475ab3#321848d0911928527ea5d94f88bcaa4587475ab3"
+source = "git+https://github.com/itchysats/rust-lightning?rev=2a0edd5c4b012ab6b166ee1c5a68e6974b93dcb2#2a0edd5c4b012ab6b166ee1c5a68e6974b93dcb2"
 dependencies = [
  "bech32 0.9.1",
  "bitcoin",
@@ -1081,7 +1081,7 @@ dependencies = [
 [[package]]
 name = "lightning-net-tokio"
 version = "0.0.112"
-source = "git+https://github.com/itchysats/rust-lightning?rev=321848d0911928527ea5d94f88bcaa4587475ab3#321848d0911928527ea5d94f88bcaa4587475ab3"
+source = "git+https://github.com/itchysats/rust-lightning?rev=2a0edd5c4b012ab6b166ee1c5a68e6974b93dcb2#2a0edd5c4b012ab6b166ee1c5a68e6974b93dcb2"
 dependencies = [
  "bitcoin",
  "lightning",
@@ -1091,7 +1091,7 @@ dependencies = [
 [[package]]
 name = "lightning-persister"
 version = "0.0.112"
-source = "git+https://github.com/itchysats/rust-lightning?rev=321848d0911928527ea5d94f88bcaa4587475ab3#321848d0911928527ea5d94f88bcaa4587475ab3"
+source = "git+https://github.com/itchysats/rust-lightning?rev=2a0edd5c4b012ab6b166ee1c5a68e6974b93dcb2#2a0edd5c4b012ab6b166ee1c5a68e6974b93dcb2"
 dependencies = [
  "bitcoin",
  "libc",
@@ -1102,7 +1102,7 @@ dependencies = [
 [[package]]
 name = "lightning-rapid-gossip-sync"
 version = "0.0.112"
-source = "git+https://github.com/itchysats/rust-lightning?rev=321848d0911928527ea5d94f88bcaa4587475ab3#321848d0911928527ea5d94f88bcaa4587475ab3"
+source = "git+https://github.com/itchysats/rust-lightning?rev=2a0edd5c4b012ab6b166ee1c5a68e6974b93dcb2#2a0edd5c4b012ab6b166ee1c5a68e6974b93dcb2"
 dependencies = [
  "bitcoin",
  "lightning",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,10 +4,10 @@ resolver = "2"
 
 [patch.crates-io]
 bdk-ldk = { git = "https://github.com/itchysats/bdk-ldk", rev = "d6e7e357b864ddb8a53c7ab5b2b38a7fc05d8dc7" } # unreleased
-lightning = { git = "https://github.com/itchysats/rust-lightning", rev = "321848d0911928527ea5d94f88bcaa4587475ab3" }
-lightning-background-processor = { git = "https://github.com/itchysats/rust-lightning", rev = "321848d0911928527ea5d94f88bcaa4587475ab3" }
-lightning-block-sync = { git = "https://github.com/itchysats/rust-lightning", rev = "321848d0911928527ea5d94f88bcaa4587475ab3" }
-lightning-invoice = { git = "https://github.com/itchysats/rust-lightning", rev = "321848d0911928527ea5d94f88bcaa4587475ab3" }
-lightning-net-tokio = { git = "https://github.com/itchysats/rust-lightning", rev = "321848d0911928527ea5d94f88bcaa4587475ab3" }
-lightning-persister = { git = "https://github.com/itchysats/rust-lightning", rev = "321848d0911928527ea5d94f88bcaa4587475ab3" }
-lightning-rapid-gossip-sync = { git = "https://github.com/itchysats/rust-lightning", rev = "321848d0911928527ea5d94f88bcaa4587475ab3" }
+lightning = { git = "https://github.com/itchysats/rust-lightning", rev = "2a0edd5c4b012ab6b166ee1c5a68e6974b93dcb2" }
+lightning-background-processor = { git = "https://github.com/itchysats/rust-lightning", rev = "2a0edd5c4b012ab6b166ee1c5a68e6974b93dcb2" }
+lightning-block-sync = { git = "https://github.com/itchysats/rust-lightning", rev = "2a0edd5c4b012ab6b166ee1c5a68e6974b93dcb2" }
+lightning-invoice = { git = "https://github.com/itchysats/rust-lightning", rev = "2a0edd5c4b012ab6b166ee1c5a68e6974b93dcb2" }
+lightning-net-tokio = { git = "https://github.com/itchysats/rust-lightning", rev = "2a0edd5c4b012ab6b166ee1c5a68e6974b93dcb2" }
+lightning-persister = { git = "https://github.com/itchysats/rust-lightning", rev = "2a0edd5c4b012ab6b166ee1c5a68e6974b93dcb2" }
+lightning-rapid-gossip-sync = { git = "https://github.com/itchysats/rust-lightning", rev = "2a0edd5c4b012ab6b166ee1c5a68e6974b93dcb2" }


### PR DESCRIPTION
latest commit includes the bugfix to persist and load custom outputs

https://github.com/itchysats/rust-lightning/commit/2a0edd5c4b012ab6b166ee1c5a68e6974b93dcb2