### PR TITLE
chore: Remove unneeded unwrap() calls

### DIFF
--- a/maker/src/main.rs
+++ b/maker/src/main.rs
@@ -9,9 +9,9 @@ use tracing::metadata::LevelFilter;
 #[rocket::main]
 async fn main() -> Result<()> {
     let path = temp_dir();
-    logger::init_tracing(LevelFilter::DEBUG, false).expect("Logger to initialise");
+    logger::init_tracing(LevelFilter::DEBUG, false)?;
     // TODO: pass in wallet parameters via clap
-    wallet::init_wallet(wallet::Network::Regtest, path.as_path()).expect("wallet to initialise");
+    wallet::init_wallet(wallet::Network::Regtest, path.as_path())?;
     let port = 9045;
 
     tokio::spawn(async move {


### PR DESCRIPTION
Ran into panic ealier today and was able to fix issue only after this change.
It's easier to debug code if it returns a result than panics.

I left out the ones inside async tasks, as they're not as trivial to remove.