### PR TITLE
Reusable hardcoded maker connection dets

### DIFF
--- a/lib/cfd_trading/cfd_order_confirmation.dart
+++ b/lib/cfd_trading/cfd_order_confirmation.dart
@@ -5,6 +5,7 @@ import 'package:go_router/go_router.dart';
 import 'package:intl/intl.dart';
 import 'package:provider/provider.dart';
 import 'package:ten_ten_one/cfd_trading/cfd_trading.dart';
+import 'package:ten_ten_one/main.dart';
 import 'package:ten_ten_one/models/amount.model.dart';
 import 'package:ten_ten_one/cfd_trading/cfd_trading_change_notifier.dart';
 import 'package:ten_ten_one/models/order.dart';
@@ -79,7 +80,10 @@ class CfdOrderConfirmation extends StatelessWidget {
 
                                 try {
                                   // TODO: Don't hardcode the values
-                                  await api.openCfd(takerAmount: 20000, leverage: 2);
+                                  await api.openCfd(
+                                      takerAmount: 20000,
+                                      leverage: 2,
+                                      makerConnection: makerIp + ":" + makerLightningPort);
                                   FLog.info(text: 'OpenCfd returned successfully');
                                 } on FfiException catch (error) {
                                   FLog.error(

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -36,6 +36,7 @@ PaymentHistory paymentHistory = PaymentHistory();
 
 const makerIp = "127.0.0.1";
 const makerLightningPort = "9045";
+const makerHttpApiPort = "8000";
 
 void main() {
   FlutterError.onError = (details) {

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -34,6 +34,9 @@ BitcoinBalance bitcoinBalance = BitcoinBalance();
 SeedBackupModel seedBackup = SeedBackupModel();
 PaymentHistory paymentHistory = PaymentHistory();
 
+const makerIp = "127.0.0.1";
+const makerLightningPort = "9045";
+
 void main() {
   FlutterError.onError = (details) {
     FlutterError.presentError(details);

--- a/rust/src/api.rs
+++ b/rust/src/api.rs
@@ -80,7 +80,7 @@ pub fn open_channel(peer_pubkey_and_ip_addr: String, channel_amount_sat: u64) ->
 }
 
 #[tokio::main(flavor = "current_thread")]
-pub async fn open_cfd(taker_amount: u64, leverage: u64) -> Result<()> {
+pub async fn open_cfd(taker_amount: u64, leverage: u64, maker_ip_port: String) -> Result<()> {
     if leverage > 2 {
         bail!("Only leverage x1 and x2 are supported at the moment");
     }
@@ -88,7 +88,7 @@ pub async fn open_cfd(taker_amount: u64, leverage: u64) -> Result<()> {
     // Hardcoded leverage of 2
     let maker_amount = taker_amount.saturating_mul(leverage);
 
-    wallet::open_cfd(taker_amount, maker_amount).await?;
+    wallet::open_cfd(taker_amount, maker_amount, maker_ip_port).await?;
 
     Ok(())
 }

--- a/rust/src/wallet.rs
+++ b/rust/src/wallet.rs
@@ -28,8 +28,6 @@ pub const REGTEST_ELECTRUM: &str = "tcp://localhost:50000";
 /// Wallet has to be managed by Rust as generics are not support by frb
 static WALLET: Storage<Mutex<Wallet>> = Storage::new();
 
-static MAKER_IP_PORT: &str = "127.0.0.1:9045";
-
 pub enum Network {
     Mainnet,
     Testnet,
@@ -243,7 +241,7 @@ pub async fn open_channel(peer_info: PeerInfo, channel_amount_sat: u64) -> Resul
     .await
 }
 
-pub async fn open_cfd(taker_amount: u64, maker_amount: u64) -> Result<()> {
+pub async fn open_cfd(taker_amount: u64, maker_amount: u64, maker_ip_port: String) -> Result<()> {
     tracing::info!("Opening CFD with taker amount {taker_amount} maker amount {maker_amount}");
 
     let (peer_manager, channel_manager) = {
@@ -263,7 +261,7 @@ pub async fn open_cfd(taker_amount: u64, maker_amount: u64) -> Result<()> {
         .context("Could not retrieve short channel id")?;
     let maker_pk = channel_details.counterparty.node_id;
 
-    let maker_connection_str = format!("{maker_pk}@{MAKER_IP_PORT}");
+    let maker_connection_str = format!("{maker_pk}@{maker_ip_port}");
 
     tracing::info!("Connection str: {maker_connection_str}");
 


### PR DESCRIPTION
Probably better to change the API to consume the connection details for now then specifying them hardcoded in rust.

Given that we need to connect to the maker's HTTP api as well this should be in one place - and I think dart should be in control of the state for now.

Note: I did not add the `pubkey` of the maker, but eventually we also have to deal with that. The textfield in `OpenChannel` has to be fixed :)