### PR TITLE
Use chosen leverage when opening a CFD

### DIFF
--- a/lib/cfd_trading/cfd_offer.dart
+++ b/lib/cfd_trading/cfd_offer.dart
@@ -16,7 +16,7 @@ import 'package:ten_ten_one/utilities/dropdown.dart';
 import 'package:ten_ten_one/utilities/tto_table.dart';
 
 class CfdOffer extends StatefulWidget {
-  static const leverages = [1, 2, 3];
+  static const leverages = [1, 2];
 
   const CfdOffer({Key? key}) : super(key: key);
 

--- a/lib/cfd_trading/cfd_order_confirmation.dart
+++ b/lib/cfd_trading/cfd_order_confirmation.dart
@@ -78,8 +78,8 @@ class CfdOrderConfirmation extends StatelessWidget {
                                 cfdTradingService.draftOrder = null;
 
                                 try {
-                                  // TODO: Don't hardcode the values
-                                  await api.openCfd(takerAmount: 20000, leverage: 2);
+                                  // TODO: Don't hardcode the taker amount
+                                  await api.openCfd(takerAmount: 20000, leverage: order.leverage);
                                   FLog.info(text: 'OpenCfd returned successfully');
                                 } on FfiException catch (error) {
                                   FLog.error(


### PR DESCRIPTION
FIxes #198.

We also limit the possible leverage values to 1 and 2 to ensure that the maker always has enough liquidity in the channel to open a CFD right after opening the channel.