### PR TITLE
chore: Do not specify maker peer info manually

### DIFF
--- a/lib/wallet/open_channel.dart
+++ b/lib/wallet/open_channel.dart
@@ -26,6 +26,7 @@ class _OpenChannelState extends State<OpenChannel> {
     super.initState();
     final bitcoinBalance = context.read<BitcoinBalance>();
     channelCapacity = bitcoinBalance.amount.asSats;
+    _setMakerPeerInfo();
   }
 
   @override
@@ -45,18 +46,7 @@ class _OpenChannelState extends State<OpenChannel> {
               const SizedBox(
                 height: 5.0,
               ),
-              TextFormField(
-                  keyboardType: TextInputType.multiline,
-                  maxLines: null,
-                  initialValue: peerPubkeyAndIpAddr,
-                  decoration: const InputDecoration(
-                      border: UnderlineInputBorder(), hintText: "pubkey@host:port"),
-                  onChanged: (text) {
-                    setState(() {
-                      peerPubkeyAndIpAddr = text;
-                    });
-                  },
-                  style: const TextStyle(fontSize: 20)),
+              Text(peerPubkeyAndIpAddr, style: const TextStyle(fontSize: 20)),
               const SizedBox(
                 height: 10.0,
               ),
@@ -108,9 +98,7 @@ class _OpenChannelState extends State<OpenChannel> {
                   onPressed: () async {
                     FLog.info(text: "Opening Channel with capacity " + channelCapacity.toString());
 
-                    api.openChannel(
-                        peerPubkeyAndIpAddr: peerPubkeyAndIpAddr,
-                        channelAmountSat: channelCapacity);
+                    api.openChannel(channelAmountSat: channelCapacity);
                     ScaffoldMessenger.of(context).showSnackBar(const SnackBar(
                       content: Text("Waiting for channel to get established"),
                     ));
@@ -122,5 +110,11 @@ class _OpenChannelState extends State<OpenChannel> {
         ),
       )),
     );
+  }
+
+// This is pre-set in the backend, so no need to hook up to a change provider
+  Future<void> _setMakerPeerInfo() async {
+    final makerPubkeyAndIpAddr = await api.makerPeerInfo();
+    setState(() => peerPubkeyAndIpAddr = makerPubkeyAndIpAddr);
   }
 }

--- a/rust/src/api.rs
+++ b/rust/src/api.rs
@@ -1,4 +1,3 @@
-use crate::disk::parse_peer_info;
 use crate::logger;
 use crate::offer;
 use crate::offer::Offer;
@@ -66,8 +65,12 @@ pub fn get_address() -> Result<Address> {
     Ok(Address::new(wallet::get_address()?.to_string()))
 }
 
-pub fn open_channel(peer_pubkey_and_ip_addr: String, channel_amount_sat: u64) -> Result<()> {
-    let peer_info = parse_peer_info(peer_pubkey_and_ip_addr)?;
+pub fn maker_peer_info() -> String {
+    wallet::maker_peer_info().to_string()
+}
+
+pub fn open_channel(channel_amount_sat: u64) -> Result<()> {
+    let peer_info = wallet::maker_peer_info();
     let rt = Runtime::new()?;
     rt.block_on(async {
         if let Err(e) = wallet::open_channel(peer_info, channel_amount_sat).await {

--- a/rust/src/wallet.rs
+++ b/rust/src/wallet.rs
@@ -32,6 +32,15 @@ static MAKER_PORT_HTTP: u64 = 8000;
 // Maker PK is derived from our checked in regtest maker seed
 static MAKER_PK: &str = "02cb6517193c466de0688b8b0386dbfb39d96c3844525c1315d44bd8e108c08bc1";
 
+pub fn maker_peer_info() -> PeerInfo {
+    PeerInfo {
+        pubkey: MAKER_PK.parse().expect("Hard-coded PK to be valid"),
+        peer_addr: format!("{MAKER_IP}:{MAKER_PORT_LIGHTNING}")
+            .parse()
+            .expect("Hard-coded PK to be valid"),
+    }
+}
+
 pub enum Network {
     Mainnet,
     Testnet,


### PR DESCRIPTION
Pass in the hard-coded values to flutter. Expose them in the API so that they
     can be displayed.