### PR TITLE
fix: Add missing output in the CI job detecting changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,7 @@ jobs:
     outputs:
       rust: ${{ steps.filter.outputs.rust }}
       flutter: ${{ steps.filter.outputs.flutter }}
+      maker: ${{ steps.filter.outputs.maker }}
     steps:
       - uses: actions/checkout@v3
       - uses: dorny/paths-filter@v2


### PR DESCRIPTION
Bors started acting up a bit, and I suspect that this might be the reason.