### PR TITLE
fix: only allow btc usd as traiding pair

### DIFF
--- a/lib/cfd_trading/cfd_offer.dart
+++ b/lib/cfd_trading/cfd_offer.dart
@@ -95,7 +95,7 @@ class _CfdOfferState extends State<CfdOffer> {
             value: order.quantity.toString(),
           ),
           Dropdown(
-              values: TradingPair.values.map((t) => t.name.toUpperCase()).toList(),
+              values: [TradingPair.btcusd.name.toUpperCase()],
               onChange: (tradingPair) {
                 order.tradingPair =
                     TradingPair.values.firstWhere((e) => e.name == tradingPair!.toLowerCase());


### PR DESCRIPTION
We currently don't support ETHUSD, hence removing the option for now,