### PR TITLE
chore: Bump bdk-ldk lib for improved error handling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -199,11 +199,13 @@ dependencies = [
 [[package]]
 name = "bdk-ldk"
 version = "0.1.0"
-source = "git+https://github.com/itchysats/bdk-ldk?rev=2241b05837a8d300bb5825245dd64647fc404cb5#2241b05837a8d300bb5825245dd64647fc404cb5"
+source = "git+https://github.com/itchysats/bdk-ldk?rev=07dc94dcaa466d9bece8636a538757c97fe3663c#07dc94dcaa466d9bece8636a538757c97fe3663c"
 dependencies = [
+ "anyhow",
  "bdk",
  "lightning",
  "serde_json",
+ "thiserror",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["rust", "maker"]
 resolver = "2"
 
 [patch.crates-io]
-bdk-ldk = { git = "https://github.com/itchysats/bdk-ldk", rev = "2241b05837a8d300bb5825245dd64647fc404cb5" } # unreleased
+bdk-ldk = { git = "https://github.com/itchysats/bdk-ldk", rev = "07dc94dcaa466d9bece8636a538757c97fe3663c" } # unreleased
 lightning = { git = "https://github.com/itchysats/rust-lightning", rev = "a4c164979300b403966bc4185a98327ebd61d294" }
 lightning-background-processor = { git = "https://github.com/itchysats/rust-lightning", rev = "a4c164979300b403966bc4185a98327ebd61d294" }
 lightning-block-sync = { git = "https://github.com/itchysats/rust-lightning", rev = "a4c164979300b403966bc4185a98327ebd61d294" }

--- a/rust/src/wallet.rs
+++ b/rust/src/wallet.rs
@@ -3,7 +3,6 @@ use crate::lightning::HTLCStatus;
 use crate::lightning::LightningSystem;
 use crate::lightning::PeerInfo;
 use crate::seed::Bip39Seed;
-use ::lightning::chain::chaininterface::BroadcasterInterface;
 use ::lightning::chain::chaininterface::ConfirmationTarget;
 use anyhow::anyhow;
 use anyhow::bail;
@@ -166,7 +165,7 @@ impl Wallet {
         let address = self
             .lightning
             .wallet
-            .get_wallet()
+            .get_wallet()?
             .get_address(AddressIndex::LastUnused)?;
         tracing::debug!(%address, "Current wallet address");
         Ok(address.address)
@@ -189,7 +188,7 @@ impl Wallet {
         let tx_history = self
             .lightning
             .wallet
-            .get_wallet()
+            .get_wallet()?
             .list_transactions(false)?;
         tracing::debug!(?tx_history, "Transaction history");
         Ok(tx_history)
@@ -211,7 +210,7 @@ impl Wallet {
     pub fn send_to_address(&self, send_to: Address, amount: u64) -> Result<Txid> {
         get_wallet()?.sync()?;
 
-        let wallet = self.lightning.wallet.get_wallet();
+        let wallet = self.lightning.wallet.get_wallet()?;
 
         let estimated_fee_rate = self
             .lightning
@@ -237,8 +236,7 @@ impl Wallet {
 
         let tx = psbt.extract_tx();
 
-        // TODO: This swallows the result internally - if we fail to broadcast we'll never know :/
-        self.lightning.wallet.broadcast_transaction(&tx);
+        self.lightning.wallet.broadcast(&tx)?;
 
         Ok(tx.txid())
     }


### PR DESCRIPTION
Reduced the number of unwraps happening inside the downstream library and addressed a TODO