### PR TITLE
chore: Do not run Android integration tests on bors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,7 +134,7 @@ jobs:
   # See: https://betterprogramming.pub/test-flutter-apps-on-android-with-github-actions-abdba2137b4
   flutter-android-test:
     needs: changes
-    if: ${{ needs.changes.outputs.rust == 'true' || needs.changes.outputs.flutter == 'true'  }}
+    if: ${{ (needs.changes.outputs.rust == 'true' || needs.changes.outputs.flutter == 'true') && github.ref == 'refs/heads/main'}}
     name: Flutter (Android) integration test
     strategy:
       matrix:


### PR DESCRIPTION
We're not using this job when deriving bors status, so we can avoid running it.
Hopefully this should make other job runners wait shorter.