### PR TITLE
Introduce CFD model and persist Cfd data

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2682,6 +2682,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "atty",
+ "base64",
  "bdk",
  "bdk-ldk",
  "bip39",
@@ -2700,6 +2701,7 @@ dependencies = [
  "rand 0.6.5",
  "reqwest",
  "rust_decimal",
+ "rust_decimal_macros",
  "serde",
  "sha2",
  "sqlx",

--- a/lib/cfd_trading/cfd_trading_change_notifier.dart
+++ b/lib/cfd_trading/cfd_trading_change_notifier.dart
@@ -1,10 +1,13 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
-import 'package:ten_ten_one/models/order.dart';
+import 'package:ten_ten_one/bridge_generated/bridge_definitions.dart';
+import 'package:ten_ten_one/ffi.io.dart' if (dart.library.html) 'ffi.web.dart';
 
 /// Responsible for managing the state across the different Cfd Trading screens.
 class CfdTradingChangeNotifier extends ChangeNotifier {
-  final List<Order> _orders = [];
-  List<Order> listOrders() => _orders;
+  List<Cfd> _cfds = [];
+  List<Cfd> listCfds() => _cfds;
 
   // the selected tab index needs to be managed in an app state as otherwise
   // a the order confirmation screen could not change tabs to the cfd overview
@@ -21,15 +24,20 @@ class CfdTradingChangeNotifier extends ChangeNotifier {
   // to null once the order has been confirmed.
   Order? draftOrder;
 
-  void persist(Order order) {
-    final index = _orders.indexWhere((o) => o.id == order.id);
+  void notify() {
+    super.notifyListeners();
+  }
 
-    if (index >= 0) {
-      _orders.removeAt(index);
-    }
+  CfdTradingChangeNotifier init() {
+    Timer.periodic(const Duration(seconds: 20), (timer) async {
+      _cfds = await api.listCfds();
+      super.notifyListeners();
+    });
+    return this;
+  }
 
-    _orders.add(order);
-
+  void update() async {
+    _cfds = await api.listCfds();
     super.notifyListeners();
   }
 }

--- a/lib/cfd_trading/position_selection.dart
+++ b/lib/cfd_trading/position_selection.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/material.dart';
-import 'package:ten_ten_one/models/order.dart';
+import 'package:ten_ten_one/bridge_generated/bridge_definitions.dart';
 
 class PositionSelection extends StatefulWidget {
   final ValueChanged<Position?>? onChange;
@@ -17,20 +17,20 @@ class _PositionSelectionState extends State<PositionSelection> {
   @override
   Widget build(BuildContext context) {
     setState(() {
-      value = value ?? widget.value ?? Position.long;
+      value = value ?? widget.value ?? Position.Long;
     });
     return Row(
       children: <Widget>[
-        Expanded(child: buildButton("Buy / Long", Position.long)),
+        Expanded(child: buildButton("Buy / Long", Position.Long)),
         const SizedBox(width: 15),
-        Expanded(child: buildButton("Sell / Short", Position.short)),
+        Expanded(child: buildButton("Sell / Short", Position.Short)),
       ],
     );
   }
 
   Widget buildButton(String text, Position position) {
     bool selected = value == position;
-    Color color = Position.long == position ? Colors.green : Colors.red;
+    Color color = Position.Long == position ? Colors.green : Colors.red;
 
     return OutlinedButton(
         onPressed: () {
@@ -45,7 +45,7 @@ class _PositionSelectionState extends State<PositionSelection> {
         style: OutlinedButton.styleFrom(
             side: BorderSide(width: 1.0, color: color),
             backgroundColor: selected
-                ? Position.long == position
+                ? Position.Long == position
                     ? Colors.green
                     : Colors.red
                 : Colors.white));

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -20,7 +20,6 @@ import 'package:ten_ten_one/wallet/wallet_change_notifier.dart';
 import 'package:ten_ten_one/models/amount.model.dart';
 import 'package:ten_ten_one/models/balance_model.dart';
 import 'package:ten_ten_one/cfd_trading/cfd_trading_change_notifier.dart';
-import 'package:ten_ten_one/models/order.dart';
 import 'package:ten_ten_one/models/seed_backup_model.dart';
 import 'package:ten_ten_one/wallet/receive.dart';
 import 'package:ten_ten_one/wallet/seed.dart';
@@ -52,7 +51,7 @@ void main() {
     ChangeNotifierProvider(create: (context) => bitcoinBalance),
     ChangeNotifierProvider(create: (context) => seedBackup),
     ChangeNotifierProvider(create: (context) => paymentHistory),
-    ChangeNotifierProvider(create: (context) => CfdTradingChangeNotifier()),
+    ChangeNotifierProvider(create: (context) => CfdTradingChangeNotifier().init()),
     ChangeNotifierProvider(create: (context) => WalletChangeNotifier()),
     ChangeNotifierProvider(create: (context) => cfdOffersChangeNotifier),
   ], child: const TenTenOneApp()));
@@ -146,7 +145,7 @@ class _TenTenOneState extends State<TenTenOneApp> {
             GoRoute(
               path: CfdOrderDetail.subRouteName,
               builder: (BuildContext context, GoRouterState state) {
-                return CfdOrderDetail(order: state.extra as Order);
+                return CfdOrderDetail(cfd: state.extra as Cfd);
               },
             ),
           ]),

--- a/lib/models/order.dart
+++ b/lib/models/order.dart
@@ -1,81 +1,11 @@
 import 'package:font_awesome_flutter/font_awesome_flutter.dart';
 import 'package:flutter/material.dart';
-import 'package:ten_ten_one/models/amount.model.dart';
-import 'package:uuid/uuid.dart';
+import 'package:ten_ten_one/bridge_generated/bridge_definitions.dart';
 
-enum Position {
-  long,
-  short,
-}
-
-enum TradingPair {
-  btcusd,
-  ethusd,
-}
-
-extension TradingPairExtension on TradingPair {
+extension ContractSymbolExtension on ContractSymbol {
   static const icons = {
-    TradingPair.btcusd: FontAwesomeIcons.bitcoin,
-    TradingPair.ethusd: FontAwesomeIcons.ethereum
+    ContractSymbol.BtcUsd: FontAwesomeIcons.bitcoin,
+    ContractSymbol.EthUsd: FontAwesomeIcons.ethereum
   };
   IconData get icon => icons[this]!;
-}
-
-enum OrderStatus {
-  draft,
-  pending,
-  open,
-  closed,
-  failed,
-}
-
-extension OrderStatusExtension on OrderStatus {
-  static const displays = {
-    OrderStatus.draft: "Draft",
-    OrderStatus.pending: "Contract Setup",
-    OrderStatus.open: "Open",
-    OrderStatus.closed: "Closed",
-    OrderStatus.failed: "Failed",
-  };
-
-  String get display => displays[this]!;
-}
-
-class Order {
-  late String id;
-
-  OrderStatus status;
-
-  int liquidationPrice;
-  int openPrice;
-  int quantity;
-  int leverage;
-
-  Amount fundingRate;
-  Amount margin;
-  Amount pl;
-  Amount estimatedFees;
-
-  DateTime expiry;
-  late DateTime updated;
-
-  TradingPair tradingPair;
-  Position position;
-
-  Order(
-      {required this.fundingRate,
-      required this.margin,
-      required this.expiry,
-      required this.liquidationPrice,
-      required this.openPrice,
-      required this.pl,
-      required this.quantity,
-      required this.estimatedFees,
-      this.tradingPair = TradingPair.btcusd,
-      this.position = Position.long,
-      this.leverage = 2,
-      this.status = OrderStatus.draft}) {
-    updated = DateTime.now();
-    id = const Uuid().v4();
-  }
 }

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -10,6 +10,7 @@ crate-type = ["lib", "cdylib", "staticlib"] # Android needs cdylib, whereas iOS 
 [dependencies]
 anyhow = { version = "1", features = ["backtrace"] }
 atty = "0.2"
+base64 = "0.13.1"
 bdk = "0.24.0"
 bdk-ldk = "0.1.0"
 bip39 = "1.0.1"
@@ -28,6 +29,7 @@ lightning-rapid-gossip-sync = { version = "0.0.112" }
 rand = "^0.6.0"
 reqwest = { version = "0.11", default-features = false, features = ["json", "rustls-tls-webpki-roots"] }
 rust_decimal = { version = "1", features = ["serde-with-float"] }
+rust_decimal_macros = "1.26"
 serde = "1.0.147"
 sha2 = "0.10"
 sqlx = { version = "0.6.2", features = ["offline", "sqlite", "uuid", "runtime-tokio-rustls"] }

--- a/rust/migrations/202211170900_create_cfd_table.sql
+++ b/rust/migrations/202211170900_create_cfd_table.sql
@@ -1,0 +1,32 @@
+CREATE TABLE IF NOT EXISTS cfd_state (
+    id INTEGER PRIMARY KEY,
+    state TEXT NOT NULL
+);
+INSERT INTO
+    cfd_state (id, state)
+VALUES
+    (1, "Open");
+INSERT INTO
+    cfd_state (id, state)
+VALUES
+    (2, "Closed");
+INSERT INTO
+    cfd_state (id, state)
+VALUES
+    (3, "Failed");
+CREATE TABLE IF NOT EXISTS cfd (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    custom_output_id TEXT UNIQUE NOT NULL,
+    contract_symbol TEXT NOT NULL,
+    position TEXT NOT NULL,
+    leverage INTEGER NOT NULL,
+    updated INTEGER NOT NULL,
+    created INTEGER NOT NULL,
+    state_id INTEGER NOT NULL,
+    quantity INTEGER NOT NULL,
+    expiry INTEGER NOT NULL,
+    open_price REAL NOT NULL,
+    liquidation_price REAL NOT NULL,
+    FOREIGN KEY(state_id) REFERENCES cfd_state(id)
+);
+CREATE UNIQUE INDEX IF NOT EXISTS dlc_id ON cfd(custom_output_id);

--- a/rust/prepare_db.sh
+++ b/rust/prepare_db.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+TEMPDB=${PWD}/tempdb
+
+# make sure to fail early in case something goes wrong
+set -e
+
+# create temporary DB
+DATABASE_URL=sqlite:${TEMPDB} cargo sqlx database create
+# make sure we remove the tempdb when exiting even if one of the following commands fails
+trap 'rm -f ${TEMPDB}' EXIT
+
+# run the migration scripts to create the tables
+DATABASE_URL=sqlite:${TEMPDB} cargo sqlx migrate run
+
+# prepare the sqlx-data.json rust mappings
+DATABASE_URL=sqlite:${TEMPDB} SQLX_OFFLINE=true cargo sqlx prepare -- --tests

--- a/rust/sqlx-data.json
+++ b/rust/sqlx-data.json
@@ -1,0 +1,87 @@
+{
+  "db": "SQLite",
+  "32d194b30314ecad8cd44e3415328e5ec8a83c4dd8b03ed36bd073e4838f294a": {
+    "describe": {
+      "columns": [
+        {
+          "name": "id",
+          "ordinal": 0,
+          "type_info": "Int64"
+        },
+        {
+          "name": "custom_output_id",
+          "ordinal": 1,
+          "type_info": "Text"
+        },
+        {
+          "name": "contract_symbol: crate::cfd::ContractSymbol",
+          "ordinal": 2,
+          "type_info": "Text"
+        },
+        {
+          "name": "position: crate::cfd::Position",
+          "ordinal": 3,
+          "type_info": "Text"
+        },
+        {
+          "name": "leverage",
+          "ordinal": 4,
+          "type_info": "Int64"
+        },
+        {
+          "name": "updated",
+          "ordinal": 5,
+          "type_info": "Int64"
+        },
+        {
+          "name": "created",
+          "ordinal": 6,
+          "type_info": "Int64"
+        },
+        {
+          "name": "state: crate::cfd::CfdState",
+          "ordinal": 7,
+          "type_info": "Text"
+        },
+        {
+          "name": "quantity",
+          "ordinal": 8,
+          "type_info": "Int64"
+        },
+        {
+          "name": "expiry",
+          "ordinal": 9,
+          "type_info": "Int64"
+        },
+        {
+          "name": "open_price",
+          "ordinal": 10,
+          "type_info": "Float"
+        },
+        {
+          "name": "liquidation_price",
+          "ordinal": 11,
+          "type_info": "Float"
+        }
+      ],
+      "nullable": [
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        false
+      ],
+      "parameters": {
+        "Right": 0
+      }
+    },
+    "query": "\n            select\n                cfd.id as id,\n                custom_output_id,\n                contract_symbol as \"contract_symbol: crate::cfd::ContractSymbol\",\n                position as \"position: crate::cfd::Position\",\n                leverage,\n                updated,\n                created,\n                cfd_state.state as \"state: crate::cfd::CfdState\",\n                quantity,\n                expiry,\n                open_price,\n                liquidation_price\n            from\n                cfd\n            inner join cfd_state on cfd.state_id = cfd_state.id\n            "
+  }
+}

--- a/rust/src/calc.rs
+++ b/rust/src/calc.rs
@@ -1,0 +1,45 @@
+pub mod inverse {
+    use rust_decimal::Decimal;
+
+    pub fn calculate_long_liquidation_price(leverage: Decimal, price: Decimal) -> Decimal {
+        price * leverage / (leverage + Decimal::ONE)
+    }
+
+    /// Calculate liquidation price for the party going short.
+    pub fn calculate_short_liquidation_price(leverage: Decimal, price: Decimal) -> Decimal {
+        // If the leverage is equal to 1, the liquidation price will go towards infinity
+        if leverage == Decimal::ONE {
+            return rust_decimal_macros::dec!(21_000_000);
+        }
+        price * leverage / (leverage - Decimal::ONE)
+    }
+}
+
+pub mod quanto {
+    use rust_decimal::Decimal;
+    use rust_decimal::RoundingStrategy;
+
+    /// Compute the closing price under which the party going long should get liquidated.
+    pub fn bankruptcy_price_long(initial_price: Decimal, leverage: Decimal) -> Decimal {
+        let shift = bankruptcy_price_shift(initial_price, leverage);
+
+        initial_price - shift
+    }
+
+    /// Compute the closing price over which the party going short should get liquidated.
+    pub fn bankruptcy_price_short(initial_price: Decimal, leverage: Decimal) -> Decimal {
+        let shift = bankruptcy_price_shift(initial_price, leverage);
+
+        initial_price + shift
+    }
+
+    /// By how much the price of the asset needs to shift from the initial price in order to reach
+    /// the bankruptcy price of the party with the given `leverage`.
+    ///
+    /// This is an absolute value. How to apply it in order to calculate the bankruptcy price will
+    /// depend on the party's position.
+    fn bankruptcy_price_shift(initial_price: Decimal, leverage: Decimal) -> Decimal {
+        let shift = initial_price / leverage;
+        shift.round_dp_with_strategy(0, RoundingStrategy::ToZero)
+    }
+}

--- a/rust/src/cfd.rs
+++ b/rust/src/cfd.rs
@@ -1,0 +1,178 @@
+use crate::db;
+use crate::wallet;
+use crate::wallet::MAKER_IP;
+use crate::wallet::MAKER_PK;
+use crate::wallet::MAKER_PORT_HTTP;
+use crate::wallet::MAKER_PORT_LIGHTNING;
+use anyhow::anyhow;
+use anyhow::bail;
+use anyhow::Context;
+use anyhow::Result;
+use flutter_rust_bridge::frb;
+
+#[derive(Debug, Clone, Copy, sqlx::Type)]
+pub enum ContractSymbol {
+    BtcUsd,
+    EthUsd,
+}
+
+#[derive(Debug, Clone, Copy, sqlx::Type)]
+pub enum Position {
+    Long,
+    Short,
+}
+
+#[frb]
+#[derive(Debug, Clone, Copy, sqlx::Type)]
+pub struct Order {
+    #[frb(non_final)]
+    pub leverage: u8,
+    #[frb(non_final)]
+    pub quantity: u32,
+    #[frb(non_final)]
+    pub contract_symbol: ContractSymbol,
+    #[frb(non_final)]
+    pub position: Position,
+    pub open_price: f64,
+}
+
+#[derive(Debug, Clone, Copy, sqlx::Type)]
+pub enum CfdState {
+    Open,
+    Closed,
+    Failed,
+}
+
+pub struct Cfd {
+    pub id: i64,
+    pub custom_output_id: String,
+    pub contract_symbol: ContractSymbol,
+    pub position: Position,
+    pub leverage: i64,
+    pub updated: i64,
+    pub created: i64,
+    pub state: CfdState,
+    pub quantity: i64,
+    pub expiry: i64,
+    pub open_price: f64,
+    pub liquidation_price: f64,
+}
+
+pub async fn open(order: &Order) -> Result<()> {
+    // TODO: calculate liquidation price
+    let liquidation_price: f64 = 12314.23;
+    // TODO: calculate expiry of cfd
+    let expiry = time::OffsetDateTime::now_utc().unix_timestamp();
+
+    if order.leverage > 2 {
+        bail!("Only leverage x1 and x2 are supported at the moment");
+    }
+
+    let maker_amount = order.quantity.saturating_mul(order.leverage as u32);
+
+    tracing::info!(
+        "Opening CFD with taker amount {} maker amount {maker_amount}",
+        order.quantity
+    );
+
+    let channel_manager = {
+        let lightning = &wallet::get_wallet()?.lightning;
+        lightning.channel_manager.clone()
+    };
+
+    let binding = channel_manager.list_channels();
+    tracing::info!("Channels: {binding:?}");
+
+    let channel_details = binding.first().context("No first channel found")?;
+    let maker_pk = channel_details.counterparty.node_id;
+    let short_channel_id = channel_details
+        .short_channel_id
+        .context("Could not retrieve short channel id")?;
+
+    // TODO: Use  MAKER_PK meaningfully
+    assert_eq!(maker_pk.to_string(), MAKER_PK, "Using wrong maker seed");
+    let maker_connection_str = format!("{maker_pk}@{MAKER_IP}:{MAKER_PORT_LIGHTNING}");
+
+    tracing::info!("Connection str: {maker_connection_str}");
+    tracing::info!(
+        "Maker http API: {}",
+        format!("{MAKER_IP}:{MAKER_PORT_HTTP}")
+    );
+
+    // hardcoded because we are not dealing with force-close scenarios yet
+    let dummy_script = "0020e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+        .parse()
+        .expect("static dummy script to always parse");
+    let dummy_cltv_expiry = 40;
+
+    // Convert to msats
+    let taker_amount = order.quantity * 1000;
+    let maker_amount = maker_amount * 1000;
+
+    tracing::info!("Adding custom output");
+    let custom_output_details = channel_manager
+        .add_custom_output(
+            short_channel_id,
+            maker_pk,
+            taker_amount as u64,
+            maker_amount as u64,
+            dummy_cltv_expiry,
+            dummy_script,
+        )
+        .map_err(|e| anyhow!(e))?;
+    tracing::info!(?custom_output_details, "Added custom output");
+
+    let custom_output_id = base64::encode(custom_output_details.id.0);
+
+    let mut connection = db::acquire().await?;
+
+    let query_result = sqlx::query(
+        r#"
+        INSERT INTO cfd (custom_output_id, contract_symbol, position, leverage, created, updated, state_id, quantity, expiry, open_price, liquidation_price)
+        VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
+        "#,
+    )
+    .bind(custom_output_id)
+    .bind(order.contract_symbol)
+    .bind(order.position)
+    .bind(order.leverage)
+    .bind(time::OffsetDateTime::now_utc().unix_timestamp())
+        .bind(time::OffsetDateTime::now_utc().unix_timestamp())
+    .bind(1)
+    .bind(order.quantity)
+    .bind(expiry)
+    .bind(order.open_price)
+    .bind(liquidation_price).execute(&mut connection)
+        .await?;
+
+    if query_result.rows_affected() != 1 {
+        bail!("Failed to insert cfd");
+    }
+
+    tracing::info!("Successfully stored CFD to database");
+
+    Ok(())
+}
+
+pub async fn settle(taker_amount: u64, maker_amount: u64) -> Result<()> {
+    tracing::info!("Settling CFD with taker amount {taker_amount} and maker amount {maker_amount}");
+
+    let channel_manager = {
+        let lightning = &wallet::get_wallet()?.lightning;
+        lightning.channel_manager.clone()
+    };
+
+    let custom_output_id = *channel_manager
+        .custom_outputs()
+        .first()
+        .context("No custom outputs in channel")?;
+
+    let taker_amount_msats = taker_amount * 1000;
+    let maker_amount_msats = maker_amount * 1000;
+
+    channel_manager
+        .remove_custom_output(custom_output_id, taker_amount_msats, maker_amount_msats)
+        .map_err(|e| anyhow!("Failed to settle CFD: {e:?}"))?;
+
+    Ok(())
+}

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -1,5 +1,7 @@
 mod api;
 mod bridge_generated;
+mod calc;
+mod cfd;
 pub mod db;
 pub mod disk;
 mod hex_utils;


### PR DESCRIPTION
The Cfd model is to be filled with data from the rust backend. We periodically update the list of Cfds by calling the backend which loads the data from the db. We insert/update/delete the Cfd in the database according to user actions (e.g. open cfd inserts a cfd, ...).

We keep an `Order` model that is used before the CFD exists (i.e. before the custom output is added). The Order is not persisted for the duration of the tournament. We don't deal with failed `Order`s yet, but display them as failed Cfds. This is similar to what we did in ItchySats.