### PR TITLE
fix: Database directory on Linux not working

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -450,12 +450,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "convert_case"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
-
-[[package]]
 name = "cookie"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -615,19 +609,6 @@ checksum = "b846f081361125bfc8dc9d3940c84e1fd83ba54bbca7b17cd29483c828be0704"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
-]
-
-[[package]]
-name = "derive_more"
-version = "0.99.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fb810d30a7c1953f91334de7244731fc3f3c10d7fe163338a35b9f640960321"
-dependencies = [
- "convert_case",
- "proc-macro2",
- "quote",
- "rustc_version",
  "syn",
 ]
 
@@ -2140,15 +2121,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ef03e0a2b150c7a90d01faf6254c9c48a41e95fb2a8c2ac1c6f0d2b9aefc342"
 
 [[package]]
-name = "rustc_version"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
-dependencies = [
- "semver",
-]
-
-[[package]]
 name = "rustls"
 version = "0.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2297,12 +2269,6 @@ dependencies = [
  "core-foundation-sys",
  "libc",
 ]
-
-[[package]]
-name = "semver"
-version = "1.0.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e25dfac463d778e353db5be2449d1cce89bd6fd23c9f1ea21310ce6e5a1b29c4"
 
 [[package]]
 name = "serde"
@@ -2645,7 +2611,6 @@ dependencies = [
  "bip39",
  "bitcoin-bech32",
  "chrono",
- "derive_more",
  "flutter_rust_bridge",
  "futures",
  "hkdf",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -15,7 +15,6 @@ bdk-ldk = "0.1.0"
 bip39 = "1.0.1"
 bitcoin-bech32 = "0.12"
 chrono = "0.4.22" # TODO: Remove this dependency to use `time` crate instead
-derive_more = "0.99.17"
 flutter_rust_bridge = "1.49.1"
 futures = "0.3"
 hkdf = "0.12"

--- a/rust/src/wallet.rs
+++ b/rust/src/wallet.rs
@@ -29,6 +29,9 @@ use rust_decimal::prelude::FromPrimitive;
 use serde::Deserialize;
 use serde::Serialize;
 use state::Storage;
+use std::fmt;
+use std::fmt::Display;
+use std::fmt::Formatter;
 use std::path::Path;
 use std::sync::Mutex;
 use std::sync::MutexGuard;
@@ -57,11 +60,22 @@ pub fn maker_peer_info() -> PeerInfo {
     }
 }
 
-#[derive(Clone, derive_more::Display)]
+#[derive(Clone)]
 pub enum Network {
     Mainnet,
     Testnet,
     Regtest,
+}
+
+impl Display for Network {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        match self {
+            Network::Mainnet => "mainnet",
+            Network::Testnet => "testnet",
+            Network::Regtest => "regtest",
+        }
+        .fmt(f)
+    }
 }
 
 #[derive(Clone)]


### PR DESCRIPTION
Due to the automated trait implementation, the wallet tried to open the database
in "Regtest" instead of "regtest" directory :|

I should have hand-crafted this in the first place, as @bonomat suggested 😅