### PR TITLE
Require 1 confirmation when opening channels

### DIFF
--- a/rust/src/lightning.rs
+++ b/rust/src/lightning.rs
@@ -343,10 +343,10 @@ pub fn setup(
         .channel_handshake_limits
         .force_announced_channel_preference = false;
     // By setting this to 0 we indicate we accept 0-conf channels.
-    user_config.channel_handshake_config.minimum_depth = 0;
+    user_config.channel_handshake_config.minimum_depth = 1;
     // By setting `manually_accept_inbound_channels` to `true` we need to manually confirm every
     // inbound channel request.
-    user_config.manually_accept_inbound_channels = true;
+    user_config.manually_accept_inbound_channels = false;
 
     let (_channel_manager_blockhash, channel_manager) = {
         if let Ok(mut f) = std::fs::File::open(format!("{ldk_data_dir}/manager")) {


### PR DESCRIPTION
We would like to support 0-conf, but `rust-lightning` immediately closes the channel because of this snippet<sup>[1]</sup>.

The gist of it is:

- `rust-lightning` marks the channel as ready as soon as the fund transaction appears in the mempool.

- It then sees that the funding transaction has 0 confirmations. It interprets this as the transaction being unconfirmed due to a chain reorg, so it closes the channel for safety reasons.

[1]: https://github.com/lightningdevkit/rust-lightning/blob/a4c164979300b403966bc4185a98327ebd61d294/lightning/src/ln/channel.rs#L5575-L5588.

---

We could also modify `rust-lightning`, but that is slightly riskier.