### PR TITLE
chore: Remove debug banner

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -78,6 +78,7 @@ class _TenTenOneState extends State<TenTenOneApp> {
     return Visibility(
       visible: ready,
       child: MaterialApp.router(
+        debugShowCheckedModeBanner: false,
         title: 'TenTenOne',
         theme: ThemeData(primarySwatch: Colors.orange),
         routerConfig: _router,


### PR DESCRIPTION
It will be nicer to show demo without this annoying banner. We know when we're
running in debug mode.