### PR TITLE
Update maker spread through api

### DIFF
--- a/maker/src/main.rs
+++ b/maker/src/main.rs
@@ -3,6 +3,7 @@ use maker::bitmex;
 use maker::cli::Opts;
 use maker::logger;
 use maker::routes;
+use maker::routes::SpreadPrice;
 use std::time::Duration;
 use ten_ten_one::db;
 use ten_ten_one::wallet;
@@ -67,9 +68,12 @@ async fn main() -> Result<()> {
                 routes::get_new_invoice,
                 routes::get_wallet_details,
                 routes::get_channel_details,
+                routes::get_spread,
+                routes::put_spread,
             ],
         )
         .manage(quote_receiver)
+        .manage(SpreadPrice::new(15))
         .launch()
         .await?;
 


### PR DESCRIPTION
Exposes an api on the maker to set the spread manually. This is for demo purposes!

update spread like this
```
curl -X PUT http://127.0.0.1:8000/api/spread/0 # sets spread to 0.0
curl -X PUT http://127.0.0.1:8000/api/spread/-30 # sets spread to -0.03
```

get the current spread like this
```
curl http://127.0.0.1:8000/api/spread
```

Note, I am dividing any input by 1000 to simplify the put request, also I opted to use an url parameter instead of the body for convenience reasons.

resolves #275 
