### PR TITLE
fix: Use bid / ask price as closing price

### DIFF
--- a/lib/cfd_trading/cfd_overview.dart
+++ b/lib/cfd_trading/cfd_overview.dart
@@ -35,7 +35,8 @@ class _CfdOverviewState extends State<CfdOverview> {
     ];
     widgets.addAll(cfds
         .where((cfd) => [CfdState.Open].contains(cfd.state))
-        .map((cfd) => CfdTradeItem(cfd: cfd, closingPrice: offer.index))
+        .map((cfd) => CfdTradeItem(
+            cfd: cfd, closingPrice: cfd.position == Position.Long ? offer.bid : offer.ask))
         .toList());
 
     widgets.add(ExpansionTile(


### PR DESCRIPTION
The cfd overview was still calculating the pnl with the index price as a closing price.