### PR TITLE
Fix: balance is not visible on iphone

### DIFF
--- a/lib/app_bar_with_balance.dart
+++ b/lib/app_bar_with_balance.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart' hide Divider;
 import 'package:ten_ten_one/utilities/divider.dart';
 
-import 'balance.dart';
+import 'package:ten_ten_one/balance.dart';
 
 extension BalanceSelectorExtension on BalanceSelector {
   static const preferredHeightVals = {

--- a/lib/cfd_trading/cfd_trading.dart
+++ b/lib/cfd_trading/cfd_trading.dart
@@ -38,38 +38,40 @@ class _CfdTradingState extends State<CfdTrading> {
 
     const balanceSelector = BalanceSelector.lightning;
 
-    return Scaffold(
-        appBar: PreferredSize(
-            child: const AppBarWithBalance(balanceSelector: balanceSelector),
-            preferredSize: Size.fromHeight(balanceSelector.preferredHeight)),
-        drawer: const Menu(),
-        body: _pages.elementAt(cfdTradingService.selectedIndex),
-        bottomNavigationBar: BottomNavigationBar(
-          items: const <BottomNavigationBarItem>[
-            BottomNavigationBarItem(
-              icon: Icon(Icons.handshake),
-              label: 'Trade',
-            ),
-            BottomNavigationBarItem(
-              icon: Icon(Icons.format_list_bulleted_sharp),
-              label: 'My CFDs',
-            ),
-            BottomNavigationBarItem(
-              icon: Icon(Icons.candlestick_chart_sharp),
-              label: 'Market',
-            ),
-          ],
-          currentIndex: cfdTradingService.selectedIndex,
-          selectedItemColor: Theme.of(context).colorScheme.primary,
-          onTap: (index) {
-            setState(() {
-              // setting the selected index should be sufficient but for some reason
-              // this is not triggering a rebuild even though the cfd trading state
-              // is watched. A manual re-rendering is triggered through the setState
-              // hook.
-              cfdTradingService.selectedIndex = index;
-            });
-          },
-        ));
+    return SafeArea(
+      child: Scaffold(
+          appBar: PreferredSize(
+              child: const AppBarWithBalance(balanceSelector: balanceSelector),
+              preferredSize: Size.fromHeight(balanceSelector.preferredHeight)),
+          drawer: const Menu(),
+          body: _pages.elementAt(cfdTradingService.selectedIndex),
+          bottomNavigationBar: BottomNavigationBar(
+            items: const <BottomNavigationBarItem>[
+              BottomNavigationBarItem(
+                icon: Icon(Icons.handshake),
+                label: 'Trade',
+              ),
+              BottomNavigationBarItem(
+                icon: Icon(Icons.format_list_bulleted_sharp),
+                label: 'My CFDs',
+              ),
+              BottomNavigationBarItem(
+                icon: Icon(Icons.candlestick_chart_sharp),
+                label: 'Market',
+              ),
+            ],
+            currentIndex: cfdTradingService.selectedIndex,
+            selectedItemColor: Theme.of(context).colorScheme.primary,
+            onTap: (index) {
+              setState(() {
+                // setting the selected index should be sufficient but for some reason
+                // this is not triggering a rebuild even though the cfd trading state
+                // is watched. A manual re-rendering is triggered through the setState
+                // hook.
+                cfdTradingService.selectedIndex = index;
+              });
+            },
+          )),
+    );
   }
 }

--- a/lib/cfd_trading/cfd_trading.dart
+++ b/lib/cfd_trading/cfd_trading.dart
@@ -5,8 +5,8 @@ import 'package:ten_ten_one/cfd_trading/cfd_overview.dart';
 import 'package:ten_ten_one/menu.dart';
 import 'package:ten_ten_one/cfd_trading/cfd_trading_change_notifier.dart';
 
-import '../balance.dart';
-import '../app_bar_with_balance.dart';
+import 'package:ten_ten_one/balance.dart';
+import 'package:ten_ten_one/app_bar_with_balance.dart';
 
 class CfdTrading extends StatefulWidget {
   static const route = '/cfd-trading';

--- a/lib/mocks/payment_history.dart
+++ b/lib/mocks/payment_history.dart
@@ -1,7 +1,7 @@
 import 'dart:math';
 
-import '../models/amount.model.dart';
-import '../models/payment.model.dart';
+import 'package:ten_ten_one/models/amount.model.dart';
+import 'package:ten_ten_one/models/payment.model.dart';
 
 List<PaymentHistoryItem> mockPaymentHistory(int count) {
   return List<PaymentHistoryItem>.generate(count, (index) => mockPaymentHistoryItem());

--- a/lib/wallet/payment_history_list_item.dart
+++ b/lib/wallet/payment_history_list_item.dart
@@ -4,7 +4,7 @@ import 'package:intl/intl.dart';
 import 'package:ten_ten_one/models/amount.model.dart';
 import 'dart:math' as math;
 
-import '../models/payment.model.dart';
+import 'package:ten_ten_one/models/payment.model.dart';
 
 @immutable
 class PaymentHistoryListItem extends StatelessWidget {

--- a/lib/wallet/wallet_bitcoin.dart
+++ b/lib/wallet/wallet_bitcoin.dart
@@ -44,40 +44,42 @@ class _WalletBitcoinState extends State<WalletBitcoin> {
 
     const balanceSelector = BalanceSelector.bitcoin;
 
-    return Scaffold(
-      drawer: const Menu(),
-      appBar: PreferredSize(
-          child: const AppBarWithBalance(balanceSelector: balanceSelector),
-          preferredSize: Size.fromHeight(balanceSelector.preferredHeight)),
-      body: ListView(padding: const EdgeInsets.only(left: 25, right: 25), children: widgets),
-      floatingActionButton: SpeedDial(
-        icon: Icons.import_export,
-        iconTheme: const IconThemeData(size: 35),
-        activeIcon: Icons.close,
-        activeBackgroundColor: Colors.grey,
-        activeForegroundColor: Colors.white,
-        buttonSize: const Size(56.0, 56.0),
-        visible: true,
-        closeManually: false,
-        curve: Curves.bounceIn,
-        overlayColor: Colors.black,
-        overlayOpacity: 0.5,
-        elevation: 8.0,
-        shape: const CircleBorder(),
-        children: [
-          SpeedDialChild(
-            child: const Icon(Icons.download_sharp),
-            label: 'Receive',
-            labelStyle: const TextStyle(fontSize: 18.0),
-            onTap: () => GoRouter.of(context).go(ReceiveOnChain.route),
-          ),
-          SpeedDialChild(
-            child: const Icon(Icons.upload_sharp),
-            label: 'Send',
-            labelStyle: const TextStyle(fontSize: 18.0),
-            onTap: () => GoRouter.of(context).go(SendOnChain.route),
-          ),
-        ],
+    return SafeArea(
+      child: Scaffold(
+        drawer: const Menu(),
+        appBar: PreferredSize(
+            child: const AppBarWithBalance(balanceSelector: balanceSelector),
+            preferredSize: Size.fromHeight(balanceSelector.preferredHeight)),
+        body: ListView(padding: const EdgeInsets.only(left: 25, right: 25), children: widgets),
+        floatingActionButton: SpeedDial(
+          icon: Icons.import_export,
+          iconTheme: const IconThemeData(size: 35),
+          activeIcon: Icons.close,
+          activeBackgroundColor: Colors.grey,
+          activeForegroundColor: Colors.white,
+          buttonSize: const Size(56.0, 56.0),
+          visible: true,
+          closeManually: false,
+          curve: Curves.bounceIn,
+          overlayColor: Colors.black,
+          overlayOpacity: 0.5,
+          elevation: 8.0,
+          shape: const CircleBorder(),
+          children: [
+            SpeedDialChild(
+              child: const Icon(Icons.download_sharp),
+              label: 'Receive',
+              labelStyle: const TextStyle(fontSize: 18.0),
+              onTap: () => GoRouter.of(context).go(ReceiveOnChain.route),
+            ),
+            SpeedDialChild(
+              child: const Icon(Icons.upload_sharp),
+              label: 'Send',
+              labelStyle: const TextStyle(fontSize: 18.0),
+              onTap: () => GoRouter.of(context).go(SendOnChain.route),
+            ),
+          ],
+        ),
       ),
     );
   }

--- a/lib/wallet/wallet_bitcoin.dart
+++ b/lib/wallet/wallet_bitcoin.dart
@@ -1,15 +1,15 @@
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 import 'package:provider/provider.dart';
+import 'package:ten_ten_one/app_bar_with_balance.dart';
 import 'package:ten_ten_one/balance.dart';
 import 'package:ten_ten_one/wallet/payment_history_list_item.dart';
 import 'package:flutter_speed_dial/flutter_speed_dial.dart';
+import 'package:ten_ten_one/wallet/receive_on_chain.dart';
 import 'package:ten_ten_one/wallet/send_on_chain.dart';
 
-import '../menu.dart';
-import '../payment_history_change_notifier.dart';
-import '../app_bar_with_balance.dart';
-import 'receive_on_chain.dart';
+import 'package:ten_ten_one/menu.dart';
+import 'package:ten_ten_one/payment_history_change_notifier.dart';
 
 class WalletBitcoin extends StatefulWidget {
   const WalletBitcoin({Key? key}) : super(key: key);

--- a/lib/wallet/wallet_dashboard.dart
+++ b/lib/wallet/wallet_dashboard.dart
@@ -12,8 +12,8 @@ import 'package:ten_ten_one/wallet/payment_history_list_item.dart';
 import 'package:ten_ten_one/wallet/seed.dart';
 import 'package:ten_ten_one/wallet/service_card.dart';
 
-import '../menu.dart';
-import '../app_bar_with_balance.dart';
+import 'package:ten_ten_one/menu.dart';
+import 'package:ten_ten_one/app_bar_with_balance.dart';
 import 'action_card.dart';
 import 'open_channel.dart';
 

--- a/lib/wallet/wallet_dashboard.dart
+++ b/lib/wallet/wallet_dashboard.dart
@@ -80,12 +80,14 @@ class _WalletDashboardState extends State<WalletDashboard> {
 
     const balanceSelector = BalanceSelector.both;
 
-    return Scaffold(
-      drawer: const Menu(),
-      appBar: PreferredSize(
-          child: const AppBarWithBalance(balanceSelector: balanceSelector),
-          preferredSize: Size.fromHeight(balanceSelector.preferredHeight)),
-      body: ListView(padding: const EdgeInsets.only(left: 20, right: 20), children: widgets),
+    return SafeArea(
+      child: Scaffold(
+        drawer: const Menu(),
+        appBar: PreferredSize(
+            child: const AppBarWithBalance(balanceSelector: balanceSelector),
+            preferredSize: Size.fromHeight(balanceSelector.preferredHeight)),
+        body: ListView(padding: const EdgeInsets.only(left: 20, right: 20), children: widgets),
+      ),
     );
   }
 }

--- a/lib/wallet/wallet_lightning.dart
+++ b/lib/wallet/wallet_lightning.dart
@@ -48,40 +48,42 @@ class _WalletLightningState extends State<WalletLightning> {
 
     const balanceSelector = BalanceSelector.lightning;
 
-    return Scaffold(
-      drawer: const Menu(),
-      appBar: PreferredSize(
-          child: const AppBarWithBalance(balanceSelector: balanceSelector),
-          preferredSize: Size.fromHeight(balanceSelector.preferredHeight)),
-      body: ListView(padding: const EdgeInsets.only(left: 25, right: 25), children: widgets),
-      floatingActionButton: SpeedDial(
-        icon: Icons.import_export,
-        iconTheme: const IconThemeData(size: 35),
-        activeIcon: Icons.close,
-        activeBackgroundColor: Colors.grey,
-        activeForegroundColor: Colors.white,
-        buttonSize: const Size(56.0, 56.0),
-        visible: true,
-        closeManually: false,
-        curve: Curves.bounceIn,
-        overlayColor: Colors.black,
-        overlayOpacity: 0.5,
-        elevation: 8.0,
-        shape: const CircleBorder(),
-        children: [
-          SpeedDialChild(
-            child: const Icon(Icons.download_sharp),
-            label: 'Receive',
-            labelStyle: const TextStyle(fontSize: 18.0),
-            onTap: () => GoRouter.of(context).go(Receive.route),
-          ),
-          SpeedDialChild(
-            child: const Icon(Icons.upload_sharp),
-            label: 'Send',
-            labelStyle: const TextStyle(fontSize: 18.0),
-            onTap: () => GoRouter.of(context).go(Send.route),
-          ),
-        ],
+    return SafeArea(
+      child: Scaffold(
+        drawer: const Menu(),
+        appBar: PreferredSize(
+            child: const AppBarWithBalance(balanceSelector: balanceSelector),
+            preferredSize: Size.fromHeight(balanceSelector.preferredHeight)),
+        body: ListView(padding: const EdgeInsets.only(left: 25, right: 25), children: widgets),
+        floatingActionButton: SpeedDial(
+          icon: Icons.import_export,
+          iconTheme: const IconThemeData(size: 35),
+          activeIcon: Icons.close,
+          activeBackgroundColor: Colors.grey,
+          activeForegroundColor: Colors.white,
+          buttonSize: const Size(56.0, 56.0),
+          visible: true,
+          closeManually: false,
+          curve: Curves.bounceIn,
+          overlayColor: Colors.black,
+          overlayOpacity: 0.5,
+          elevation: 8.0,
+          shape: const CircleBorder(),
+          children: [
+            SpeedDialChild(
+              child: const Icon(Icons.download_sharp),
+              label: 'Receive',
+              labelStyle: const TextStyle(fontSize: 18.0),
+              onTap: () => GoRouter.of(context).go(Receive.route),
+            ),
+            SpeedDialChild(
+              child: const Icon(Icons.upload_sharp),
+              label: 'Send',
+              labelStyle: const TextStyle(fontSize: 18.0),
+              onTap: () => GoRouter.of(context).go(Send.route),
+            ),
+          ],
+        ),
       ),
     );
   }

--- a/lib/wallet/wallet_lightning.dart
+++ b/lib/wallet/wallet_lightning.dart
@@ -10,9 +10,9 @@ import 'package:ten_ten_one/wallet/send.dart';
 import 'package:ten_ten_one/wallet/service_card.dart';
 import 'package:flutter_speed_dial/flutter_speed_dial.dart';
 
-import '../menu.dart';
-import '../payment_history_change_notifier.dart';
-import '../app_bar_with_balance.dart';
+import 'package:ten_ten_one/menu.dart';
+import 'package:ten_ten_one/payment_history_change_notifier.dart';
+import 'package:ten_ten_one/app_bar_with_balance.dart';
 
 class WalletLightning extends StatefulWidget {
   const WalletLightning({Key? key}) : super(key: key);


### PR DESCRIPTION
<img width="458" alt="Screenshot 2022-11-22 at 13 46 04" src="https://user-images.githubusercontent.com/382048/203318370-c7af7a8e-b89e-40e3-9938-c4d8740ffb86.png">
<img width="424" alt="Screenshot 2022-11-22 at 13 46 00" src="https://user-images.githubusercontent.com/382048/203318387-16110891-4a94-46fe-b729-4144a59c3cd8.png">
<img width="442" alt="Screenshot 2022-11-22 at 13 45 52" src="https://user-images.githubusercontent.com/382048/203318391-2858afd2-2fce-41c9-a31c-0a6dab800dae.png">

The cfd trading screen looks a bit off in comparison to the other screens. But I didn't figure out quickly why this is the case. Leaving it as it is for now, since it isn't a priority for the tournament.

<img width="462" alt="Screenshot 2022-11-22 at 13 51 59" src="https://user-images.githubusercontent.com/382048/203318505-a5b5cb2b-9c3b-4efb-9288-5582a245aa16.png">

resolves #306 
