### PR TITLE
chore: Remove margin from cfd data model

### DIFF
--- a/rust/migrations/20221122111300_drop_margin_from_cfd_table.sql
+++ b/rust/migrations/20221122111300_drop_margin_from_cfd_table.sql
@@ -1,0 +1,3 @@
+-- Add migration script here
+ALTER TABLE
+    cfd DROP COLUMN margin;

--- a/rust/sqlx-data.json
+++ b/rust/sqlx-data.json
@@ -1,6 +1,50 @@
 {
   "db": "SQLite",
-  "0f0c8e555c6d5883787f5c99c06bf0d6e1209980fe6818eec8e2b0318e35a25e": {
+  "22a3f59e438230e12dd7bdb4fe9a824df904fb9126cbab1c15e675e36b2327f6": {
+    "describe": {
+      "columns": [],
+      "nullable": [],
+      "parameters": {
+        "Right": 11
+      }
+    },
+    "query": "\n        INSERT INTO cfd (custom_output_id, contract_symbol, position, leverage, created, updated, state_id, quantity, expiry, open_price, liquidation_price)\n        VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)\n        "
+  },
+  "2c6382b1b49584102d15338359bf36748a2d71fb36ab04cdf326cf25db610952": {
+    "describe": {
+      "columns": [
+        {
+          "name": "txid",
+          "ordinal": 0,
+          "type_info": "Text"
+        },
+        {
+          "name": "maker_amount",
+          "ordinal": 1,
+          "type_info": "Int64"
+        }
+      ],
+      "nullable": [
+        false,
+        false
+      ],
+      "parameters": {
+        "Right": 0
+      }
+    },
+    "query": "\n            select\n                txid,\n                maker_amount\n            from\n                ignore_txid\n            order by id\n            "
+  },
+  "e88a210f767e0ed152c38688789f5e7c208e2320feb16494f134ca08a66497bf": {
+    "describe": {
+      "columns": [],
+      "nullable": [],
+      "parameters": {
+        "Right": 4
+      }
+    },
+    "query": "\n        UPDATE cfd\n        SET\n            state_id = $1, updated = $2, close_price = $3\n        WHERE\n            cfd.custom_output_id = $4\n        "
+  },
+  "fef2eaf410cfdb7c339ef08835e3c997b8dfba4ff9e995a5bb0e60a8ead2063a": {
     "describe": {
       "columns": [
         {
@@ -67,11 +111,6 @@
           "name": "liquidation_price",
           "ordinal": 12,
           "type_info": "Float"
-        },
-        {
-          "name": "margin",
-          "ordinal": 13,
-          "type_info": "Float"
         }
       ],
       "nullable": [
@@ -87,57 +126,12 @@
         false,
         false,
         true,
-        false,
         false
       ],
       "parameters": {
         "Right": 0
       }
     },
-    "query": "\n            select\n                cfd.id as id,\n                custom_output_id,\n                contract_symbol as \"contract_symbol: crate::cfd::ContractSymbol\",\n                position as \"position: crate::cfd::Position\",\n                leverage,\n                updated,\n                created,\n                cfd_state.state as \"state: crate::cfd::CfdState\",\n                quantity,\n                expiry,\n                open_price,\n                close_price,\n                liquidation_price,\n                margin\n            from\n                cfd\n            inner join cfd_state on cfd.state_id = cfd_state.id\n            "
-  },
-  "2c6382b1b49584102d15338359bf36748a2d71fb36ab04cdf326cf25db610952": {
-    "describe": {
-      "columns": [
-        {
-          "name": "txid",
-          "ordinal": 0,
-          "type_info": "Text"
-        },
-        {
-          "name": "maker_amount",
-          "ordinal": 1,
-          "type_info": "Int64"
-        }
-      ],
-      "nullable": [
-        false,
-        false
-      ],
-      "parameters": {
-        "Right": 0
-      }
-    },
-    "query": "\n            select\n                txid,\n                maker_amount\n            from\n                ignore_txid\n            order by id\n            "
-  },
-  "d1f3f4266a6e59914d5f2952c0eeb3a0b98b93b05303ed43c730cef18152dd32": {
-    "describe": {
-      "columns": [],
-      "nullable": [],
-      "parameters": {
-        "Right": 12
-      }
-    },
-    "query": "\n        INSERT INTO cfd (custom_output_id, contract_symbol, position, leverage, created, updated, state_id, quantity, expiry, open_price, liquidation_price, margin)\n        VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)\n        "
-  },
-  "e88a210f767e0ed152c38688789f5e7c208e2320feb16494f134ca08a66497bf": {
-    "describe": {
-      "columns": [],
-      "nullable": [],
-      "parameters": {
-        "Right": 4
-      }
-    },
-    "query": "\n        UPDATE cfd\n        SET\n            state_id = $1, updated = $2, close_price = $3\n        WHERE\n            cfd.custom_output_id = $4\n        "
+    "query": "\n            select\n                cfd.id as id,\n                custom_output_id,\n                contract_symbol as \"contract_symbol: crate::cfd::ContractSymbol\",\n                position as \"position: crate::cfd::Position\",\n                leverage,\n                updated,\n                created,\n                cfd_state.state as \"state: crate::cfd::CfdState\",\n                quantity,\n                expiry,\n                open_price,\n                close_price,\n                liquidation_price\n            from\n                cfd\n            inner join cfd_state on cfd.state_id = cfd_state.id\n            "
   }
 }

--- a/rust/src/cfd.rs
+++ b/rust/src/cfd.rs
@@ -58,7 +58,6 @@ pub struct Cfd {
     pub open_price: f64,
     pub close_price: Option<f64>,
     pub liquidation_price: f64,
-    pub margin: f64,
 }
 
 impl Cfd {
@@ -133,11 +132,10 @@ pub async fn open(order: &Order) -> Result<()> {
 
     let created = time::OffsetDateTime::now_utc().unix_timestamp();
     let updated = time::OffsetDateTime::now_utc().unix_timestamp();
-    let margin_taker = margin_taker as i64;
     let query_result = sqlx::query!(
         r#"
-        INSERT INTO cfd (custom_output_id, contract_symbol, position, leverage, created, updated, state_id, quantity, expiry, open_price, liquidation_price, margin)
-        VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)
+        INSERT INTO cfd (custom_output_id, contract_symbol, position, leverage, created, updated, state_id, quantity, expiry, open_price, liquidation_price)
+        VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
         "#,
         custom_output_id,
         order.contract_symbol,
@@ -150,7 +148,6 @@ pub async fn open(order: &Order) -> Result<()> {
         expiry,
         order.open_price,
         liquidation_price,
-        margin_taker
     ).execute(&mut connection).await?;
 
     if query_result.rows_affected() != 1 {
@@ -263,7 +260,6 @@ mod tests {
             open_price: 15_587.625,
             close_price: None,
             liquidation_price: 10_000.0,
-            margin: 0.00319536,
         };
 
         let closing_price = 16_078.615;

--- a/rust/src/db.rs
+++ b/rust/src/db.rs
@@ -73,8 +73,7 @@ pub async fn load_cfds(conn: &mut SqliteConnection) -> Result<Vec<Cfd>> {
                 expiry,
                 open_price,
                 close_price,
-                liquidation_price,
-                margin
+                liquidation_price
             from
                 cfd
             inner join cfd_state on cfd.state_id = cfd_state.id
@@ -98,7 +97,6 @@ pub async fn load_cfds(conn: &mut SqliteConnection) -> Result<Vec<Cfd>> {
             contract_symbol: row.contract_symbol,
             expiry: row.expiry,
             liquidation_price: row.liquidation_price,
-            margin: row.margin,
             close_price: row.close_price,
         };
 


### PR DESCRIPTION
We don't need to store the margin on the cfd as it can be calculated from the other attributes.

Note: this is just a clean up and does not need to get merged. Feel free to skip the PR until after the tournament.