### PR TITLE
fix: bid/ask were flipped.

### DIFF
--- a/maker/src/routes.rs
+++ b/maker/src/routes.rs
@@ -45,8 +45,8 @@ pub async fn get_offer(
 
     match quote {
         Some(quote) => Ok(Json(Offer {
-            bid: (quote.ask * (Decimal::ONE + spread)),
-            ask: (quote.bid * (Decimal::ONE - spread)),
+            bid: (quote.bid * (Decimal::ONE - spread)),
+            ask: (quote.ask * (Decimal::ONE + spread)),
             index: quote.index,
         })),
         None => Err("No quotes found"),


### PR DESCRIPTION
We don't need to flip bid/ask. Think about this:
- taker comes and goes long: he gets the ask price
- if we hedge on BitMEX, we get the ask price there as well
- to make a profit, we need to get a better ask price on BitMEX then we give to the taker --> no need to flip bid/ask