### PR TITLE
Catch the case where we return an `HttpApiError` instead of the response

### DIFF
--- a/rust/src/offer.rs
+++ b/rust/src/offer.rs
@@ -1,5 +1,7 @@
 use anyhow::anyhow;
+use anyhow::bail;
 use anyhow::Result;
+use reqwest::StatusCode;
 use serde::Deserialize;
 use serde::Serialize;
 
@@ -24,6 +26,14 @@ pub async fn get_offer() -> Result<Option<Offer>> {
             return Ok(None);
         }
     };
+
+    if response.status() == StatusCode::NOT_FOUND
+        || response.status() == StatusCode::INTERNAL_SERVER_ERROR
+    {
+        let response = response.text().await?;
+        bail!("Failed to fetch offer: {response}")
+    }
+
     let result = response
         .json::<Offer>()
         .await


### PR DESCRIPTION
Initially the maker may return an `No quotes found` message as response with status code `NOT_FOUND`. This does not result in an `Err` on the client, but in a response that cannot be deserialized.