### PR TITLE
fix: Constrain qr code maximum size

### DIFF
--- a/lib/wallet/receive_on_chain.dart
+++ b/lib/wallet/receive_on_chain.dart
@@ -49,8 +49,9 @@ class _ReceiveOnChainState extends State<ReceiveOnChain> {
                   padding: const EdgeInsets.all(20.0),
                   child: Column(
                     children: [
-                      Padding(
-                        padding: const EdgeInsets.all(20.0),
+                      SizedBox(
+                        height: 250,
+                        width: 250,
                         child: QrImage(
                           data: address,
                         ),


### PR DESCRIPTION
Just as the receive on-chain, constrain the size of the QR code to 250x250px.
This prevents it from overflowing when width of the app is greater than
height (e.g. in landscape mode on phone or on desktop).