### PR TITLE
fix: Recover connection after taker or maker disconnect.

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -208,6 +208,11 @@ class _TenTenOneState extends State<TenTenOneApp> {
           .then((value) => FLog.info(text: "ldk node stopped."))
           .catchError((error) => FLog.error(text: "ldk stopped with an error", exception: error));
 
+      // connect to the maker, this will not return unless there was an error.
+      api.connect().then((value) => FLog.error(text: "Lost connection to the maker")).catchError(
+          (error) =>
+              FLog.error(text: "Lost connection to the maker with an error", exception: error));
+
       FLog.info(text: "TenTenOne is ready!");
       setState(() {
         ready = true;

--- a/lib/wallet/open_channel.dart
+++ b/lib/wallet/open_channel.dart
@@ -1,6 +1,7 @@
 import 'package:f_logs/f_logs.dart';
 import 'package:flutter/material.dart' hide Divider;
 import 'package:flutter/services.dart';
+import 'package:flutter_rust_bridge/flutter_rust_bridge.dart';
 import 'package:go_router/go_router.dart';
 import 'package:provider/provider.dart';
 import 'package:ten_ten_one/balance.dart';
@@ -121,12 +122,19 @@ class _OpenChannelState extends State<OpenChannel> {
                   onPressed: () async {
                     FLog.info(
                         text: "Opening Channel with capacity " + takerChannelAmount.toString());
-
-                    api.openChannel(takerAmount: takerChannelAmount);
-                    ScaffoldMessenger.of(context).showSnackBar(const SnackBar(
-                      content: Text("Waiting for channel to get established"),
-                    ));
-                    context.go('/');
+                    try {
+                      await api.openChannel(takerAmount: takerChannelAmount);
+                      ScaffoldMessenger.of(context).showSnackBar(const SnackBar(
+                        content: Text("Waiting for channel to get established"),
+                      ));
+                      context.go('/');
+                    } on FfiException catch (error) {
+                      FLog.error(text: "Failed to open channel.", exception: error);
+                      ScaffoldMessenger.of(context).showSnackBar(const SnackBar(
+                        backgroundColor: Colors.red,
+                        content: Text("Failed to open channel. Is the maker online?"),
+                      ));
+                    }
                   },
                   child: const Text('Open Channel')),
             ),

--- a/maker/src/main.rs
+++ b/maker/src/main.rs
@@ -73,6 +73,7 @@ async fn main() -> Result<()> {
                 routes::get_channel_details,
                 routes::get_spread,
                 routes::put_spread,
+                routes::alive,
             ],
         )
         .manage(quote_receiver)

--- a/maker/src/routes.rs
+++ b/maker/src/routes.rs
@@ -9,6 +9,8 @@ use rocket::serde::Deserialize;
 use rocket::serde::Serialize;
 use rocket::State;
 use rust_decimal::Decimal;
+use ten_ten_one::lightning::PeerInfo;
+use ten_ten_one::wallet;
 use ten_ten_one::wallet::create_invoice;
 use ten_ten_one::wallet::force_close_channel;
 use ten_ten_one::wallet::get_address;
@@ -132,6 +134,11 @@ pub fn get_wallet_details() -> Result<Json<WalletDetails>, HttpApiProblem> {
         balance,
         node_id,
     }))
+}
+
+#[rocket::get("/alive")]
+pub async fn alive() -> Result<Json<PeerInfo>, HttpApiProblem> {
+    Ok(Json(wallet::maker_peer_info()))
 }
 
 #[rocket::post("/channel/close/<remote_node_id>")]

--- a/rust/src/lightning.rs
+++ b/rust/src/lightning.rs
@@ -67,6 +67,7 @@ use lightning_persister::FilesystemPersister;
 use rand::thread_rng;
 use rand::Rng;
 use rand::RngCore;
+use serde::Serialize;
 use state::Storage;
 use std::collections::hash_map::Entry;
 use std::collections::HashMap;
@@ -107,6 +108,7 @@ pub struct LightningSystem {
     pub network: Network,
 }
 
+#[derive(Serialize)]
 pub struct PeerInfo {
     pub pubkey: PublicKey,
     pub peer_addr: SocketAddr,
@@ -128,17 +130,12 @@ impl LightningSystem {
 }
 
 pub async fn open_channel(
-    peer_manager: Arc<PeerManager>,
     channel_manager: Arc<ChannelManager>,
     peer_info: PeerInfo,
     channel_amount_sat: u64,
     data_dir: &Path,
     initial_send_amount_sats: Option<u64>,
 ) -> Result<()> {
-    tracing::debug!("Connection with {peer_info}");
-    connect_peer_if_necessary(&peer_info, peer_manager).await?;
-    tracing::debug!("Connected to {peer_info}");
-
     let config = UserConfig {
         channel_handshake_limits: ChannelHandshakeLimits {
             // lnd's max to_self_delay is 2016, so we want to be compatible.

--- a/rust/src/wallet.rs
+++ b/rust/src/wallet.rs
@@ -527,17 +527,15 @@ pub async fn open_channel(peer_info: PeerInfo, taker_amount: u64) -> Result<()> 
     }
 
     // Open Channel
-    let (peer_manager, channel_manager, data_dir) = {
+    let (channel_manager, data_dir) = {
         let lightning = &get_wallet()?.lightning;
         (
-            lightning.peer_manager.clone(),
             lightning.channel_manager.clone(),
             lightning.data_dir.clone(),
         )
     };
 
     lightning::open_channel(
-        peer_manager,
         channel_manager,
         peer_info,
         channel_capacity,
@@ -545,6 +543,19 @@ pub async fn open_channel(peer_info: PeerInfo, taker_amount: u64) -> Result<()> 
         Some(maker_amount),
     )
     .await
+}
+
+pub async fn connect() -> Result<()> {
+    let peer_manager = {
+        let lightning = &get_wallet()?.lightning;
+
+        lightning.peer_manager.clone()
+    };
+    let peer_info = maker_peer_info();
+    tracing::debug!("Connection with {peer_info}");
+    lightning::connect_peer_if_necessary(&peer_info, peer_manager).await?;
+    tracing::debug!("Connected with {peer_info}");
+    Ok(())
 }
 
 pub async fn force_close_channel(remote_node_id: PublicKey) -> Result<()> {


### PR DESCRIPTION
This PR improves the way 10101 is managing connections with the maker by introducing a dedicated connect api.

Among other improvements this PR fixes the following error.

```
flutter: {CfdOrderConfirmation} {build} {Failed to open CFD: Peer for first hop currently disconnected/pending monitor update!} {FfiException(RESULT\_ERROR, Peer for first hop currently disconnected/pending monitor update!, null)} {LogLevel.ERROR} {21 November 2022 02:04:37 PM}
```

 - Instead of blocking indefinitely when creating a channel to keep the channel alive, we now connect to the maker upon startup. Before a new thread was kept alive indefinitely everytime a new channel has been created. The thread pool was very limited though resulting into other request not getting processed and blocked!
 
 - Check if the maker is alive and try to connect once alive. Before we never checked if the connection actually succeeded, I've added a corresponding error handling. I am not very happy with checking via an http api if the maker is still alive. We see in the logs that the peer manager gets notified about a disconnect, but I didn't find a way of getting that out of the peer manager - hence the workaround over the maker alive api.


![connect](https://user-images.githubusercontent.com/382048/203608689-126e51c5-69be-49eb-b868-36e0430f21d3.gif)

An additional improvement would be to have only one thread indefinitely running and combine the run ldk node and connect together into one api call. I will create a follow up PR for that, but this is already sufficient for a testnet release.

resolves #341 