### PR TITLE
fix: Don't display full lightning invoice

### DIFF
--- a/lib/wallet/receive.dart
+++ b/lib/wallet/receive.dart
@@ -134,7 +134,7 @@ class _ReceiveState extends State<Receive> {
                               children: [
                                 Text(
                                   invoice,
-                                  overflow: TextOverflow.fade,
+                                  overflow: TextOverflow.ellipsis,
                                   style: const TextStyle(fontSize: 20),
                                 ),
                                 IconButton(

--- a/lib/wallet/receive_on_chain.dart
+++ b/lib/wallet/receive_on_chain.dart
@@ -64,7 +64,7 @@ class _ReceiveOnChainState extends State<ReceiveOnChain> {
                           Expanded(
                               child: Text(
                             address,
-                            overflow: TextOverflow.fade,
+                            overflow: TextOverflow.ellipsis,
                             style: const TextStyle(fontSize: 20),
                           )),
                           IconButton(


### PR DESCRIPTION
Lightning invoice is too long to be displayed in full and it overflows.