### PR TITLE
fix: Catch exception during wallet sync

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -230,10 +230,14 @@ class _TenTenOneState extends State<TenTenOneApp> {
   }
 
   Future<void> _callSync() async {
-    final balance = await api.getBalance();
-    bitcoinBalance.update(Amount(balance.onChain.confirmed));
-    lightningBalance.update(Amount(balance.offChain));
-    FLog.trace(text: 'Successfully synced Bitcoin wallet');
+    try {
+      final balance = await api.getBalance();
+      bitcoinBalance.update(Amount(balance.onChain.confirmed));
+      lightningBalance.update(Amount(balance.offChain));
+      FLog.trace(text: 'Successfully synced Bitcoin wallet');
+    } catch (error) {
+      FLog.error(text: "Failed to sync wallet:" + error.toString());
+    }
   }
 
   Future<void> _callGetOffers() async {


### PR DESCRIPTION
All anyhow::Result<> going through API are coming up as exceptions, and we need
to be mindful whenever we call Rust api that returns one - we should always
wrap them in a try/catch block.