### PR TITLE
feat: Support testnet

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -198,9 +198,8 @@ class _TenTenOneState extends State<TenTenOneApp> {
       final appSupportDir = await getApplicationSupportDirectory();
       FLog.info(text: "App data will be stored in: " + appSupportDir.toString());
 
-      await api.initWallet(network: Network.Regtest, path: appSupportDir.path);
-      await api.initDb(network: Network.Regtest, appDir: appSupportDir.path);
-      await api.testDbConnection(); // TODO: Remove this call after testing DB
+      await api.initWallet(path: appSupportDir.path);
+      await api.initDb(appDir: appSupportDir.path);
 
       FLog.info(text: "Starting ldk node");
       api

--- a/maker/src/cli.rs
+++ b/maker/src/cli.rs
@@ -3,9 +3,6 @@ use clap::Parser;
 use std::env::current_dir;
 use std::net::SocketAddr;
 use std::path::PathBuf;
-use ten_ten_one::wallet::MAINNET_ELECTRUM;
-use ten_ten_one::wallet::REGTEST_ELECTRUM;
-use ten_ten_one::wallet::TESTNET_ELECTRUM;
 
 #[derive(Parser)]
 pub struct Opts {
@@ -20,34 +17,12 @@ pub struct Opts {
     /// Where to permanently store data, defaults to the current working directory.
     #[clap(long)]
     data_dir: Option<PathBuf>,
-
-    #[clap(subcommand)]
-    network: Option<Network>,
 }
 
 impl Opts {
     // use this method to parse the options from the cli.
     pub fn read() -> Opts {
         Opts::parse()
-    }
-
-    pub fn network(&self) -> ten_ten_one::wallet::Network {
-        match self.network {
-            None => ten_ten_one::wallet::Network::Regtest,
-            Some(Network::Mainnet { .. }) => ten_ten_one::wallet::Network::Mainnet,
-            Some(Network::Testnet { .. }) => ten_ten_one::wallet::Network::Testnet,
-            Some(Network::Regtest { .. }) => ten_ten_one::wallet::Network::Regtest,
-        }
-    }
-
-    pub fn electrum(&self) -> String {
-        match &self.network {
-            None => REGTEST_ELECTRUM,
-            Some(Network::Mainnet { electrum })
-            | Some(Network::Testnet { electrum })
-            | Some(Network::Regtest { electrum }) => electrum,
-        }
-        .to_string()
     }
 
     pub fn data_dir(&self) -> Result<PathBuf> {
@@ -58,26 +33,4 @@ impl Opts {
         .join("maker");
         Ok(data_dir)
     }
-}
-
-#[derive(Parser, Clone)]
-pub enum Network {
-    /// Run on mainnet (default)
-    Mainnet {
-        /// URL to the electrum backend to use for the wallet.
-        #[clap(long, default_value = MAINNET_ELECTRUM)]
-        electrum: String,
-    },
-    /// Run on testnet
-    Testnet {
-        /// URL to the electrum backend to use for the wallet.
-        #[clap(long, default_value = TESTNET_ELECTRUM)]
-        electrum: String,
-    },
-    /// Run on regtest
-    Regtest {
-        /// URL to the electrum backend to use for the wallet.
-        #[clap(long, default_value = REGTEST_ELECTRUM)]
-        electrum: String,
-    },
 }

--- a/maker/src/main.rs
+++ b/maker/src/main.rs
@@ -15,14 +15,13 @@ async fn main() -> Result<()> {
     let opts = Opts::read();
 
     let path = opts.data_dir()?;
-    let network = opts.network();
     let lightning_p2p_address = opts.lightning_p2p_address;
     let http_address = opts.http_address;
-    let electrum_url = opts.electrum();
 
     logger::init_tracing(LevelFilter::DEBUG, false)?;
-    wallet::init_wallet(network.clone(), electrum_url.as_str(), path.as_path())?;
+    wallet::init_wallet(path.as_path())?;
 
+    let network = ten_ten_one::config::network();
     db::init_db(&path.join(network.to_string()).join("maker.sqlite"))
         .await
         .expect("maker db to initialise");

--- a/maker/src/routes.rs
+++ b/maker/src/routes.rs
@@ -9,6 +9,7 @@ use rocket::serde::Deserialize;
 use rocket::serde::Serialize;
 use rocket::State;
 use rust_decimal::Decimal;
+use ten_ten_one::config::maker_peer_info;
 use ten_ten_one::lightning::NodeInfo;
 use ten_ten_one::lightning::PeerInfo;
 use ten_ten_one::wallet;
@@ -138,7 +139,7 @@ pub fn get_wallet_details() -> Result<Json<WalletDetails>, HttpApiProblem> {
 
 #[rocket::get("/alive")]
 pub async fn alive() -> Result<Json<PeerInfo>, HttpApiProblem> {
-    Ok(Json(wallet::maker_peer_info()))
+    Ok(Json(maker_peer_info()))
 }
 
 #[rocket::post("/channel/close/<remote_node_id>?<force>")]

--- a/rust/src/cfd.rs
+++ b/rust/src/cfd.rs
@@ -1,7 +1,7 @@
+use crate::config::maker_pk;
 use crate::db;
 use crate::offer::Offer;
 use crate::wallet;
-use crate::wallet::maker_pk;
 use anyhow::anyhow;
 use anyhow::bail;
 use anyhow::Context;

--- a/rust/src/config.rs
+++ b/rust/src/config.rs
@@ -1,0 +1,110 @@
+use crate::lightning::PeerInfo;
+use anyhow::bail;
+use anyhow::Result;
+use bdk::bitcoin::secp256k1::PublicKey;
+use bdk::bitcoin::Network;
+use std::time::Duration;
+
+const MAINNET_ELECTRUM: &str = "ssl://blockstream.info:700";
+const TESTNET_ELECTRUM: &str = "ssl://blockstream.info:993";
+const REGTEST_ELECTRUM: &str = "tcp://localhost:50000";
+
+pub static MAINNET_MEMPOOL: &str = "https://mempool.space/api/v1";
+pub static TESTNET_MEMPOOL: &str = "https://mempool.space/testnet/api/v1";
+
+static REGTEST_MAKER_IP: &str = "127.0.0.1";
+static REGTEST_MAKER_PORT_HTTP: u64 = 8000;
+// Maker PK is derived from our checked in regtest maker seed
+static REGTEST_MAKER_PK: &str =
+    "02cb6517193c466de0688b8b0386dbfb39d96c3844525c1315d44bd8e108c08bc1";
+
+static MAKER_PORT_LIGHTNING: u64 = 9045;
+
+static TESTNET_MAKER_IP: &str = "35.189.57.114"; // testnet.itchysats.network
+static TESTNET_MAKER_PORT_HTTP: u64 = 8888;
+// Maker PK logged in tentenone-maker testnet container
+static TESTNET_MAKER_PK: &str =
+    "0244946473b7926c427be70925e8e99cafc3ea76dffe708e6cba8896576cf0b14d";
+
+pub static TCP_TIMEOUT: Duration = Duration::from_secs(10);
+
+/// Network the app is running
+///
+/// Defaults to testnet if nothing is specified
+pub fn network() -> Network {
+    read_network_from_env().unwrap_or(Network::Testnet)
+}
+
+pub fn electrum_url() -> String {
+    match network() {
+        Network::Bitcoin => MAINNET_ELECTRUM,
+        Network::Testnet => TESTNET_ELECTRUM,
+        Network::Signet => todo!(),
+        Network::Regtest => REGTEST_ELECTRUM,
+    }
+    .to_string()
+}
+
+pub fn maker_pk() -> PublicKey {
+    match network() {
+        Network::Testnet => TESTNET_MAKER_PK.parse().expect("Hard-coded PK to be valid"),
+        Network::Regtest => REGTEST_MAKER_PK.parse().expect("Hard-coded PK to be valid"),
+        Network::Signet => todo!(),
+        Network::Bitcoin => todo!(),
+    }
+}
+
+fn maker_ip() -> String {
+    match network() {
+        Network::Bitcoin => todo!(),
+        Network::Testnet => TESTNET_MAKER_IP.to_string(),
+        Network::Signet => todo!(),
+        Network::Regtest => REGTEST_MAKER_IP.to_string(),
+    }
+}
+
+fn maker_port_http() -> u64 {
+    match network() {
+        Network::Bitcoin => todo!(),
+        Network::Testnet => TESTNET_MAKER_PORT_HTTP,
+        Network::Signet => todo!(),
+        Network::Regtest => REGTEST_MAKER_PORT_HTTP,
+    }
+}
+
+pub fn maker_endpoint() -> String {
+    let ip = maker_ip();
+    let http = maker_port_http();
+    format!("http://{ip}:{http}")
+}
+
+pub fn maker_peer_info() -> PeerInfo {
+    let ip = maker_ip();
+    PeerInfo {
+        pubkey: maker_pk(),
+        peer_addr: format!("{ip}:{MAKER_PORT_LIGHTNING}")
+            .parse()
+            .expect("Hard-coded IP and port to be valid"),
+    }
+}
+
+/// Parse bitcoin network from command line, e.g. NETWORK=testnet
+fn read_network_from_env() -> Result<Network> {
+    let network = match std::env::var_os("NETWORK") {
+        Some(s) => s.into_string(),
+        None => bail!("ENV variable not set"),
+    }
+    .expect("to be valid unicode");
+    from_network_str(&network)
+}
+
+fn from_network_str(s: &str) -> Result<Network> {
+    match s {
+        "testnet" => Ok(Network::Testnet),
+        "regtest" => Ok(Network::Regtest),
+        "mainnet" => Ok(Network::Bitcoin),
+        "bitcoin" => Ok(Network::Bitcoin),
+        "signet" => Ok(Network::Signet),
+        _ => bail!("Unsupported network"),
+    }
+}

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -2,6 +2,7 @@ mod api;
 mod bridge_generated;
 mod calc;
 mod cfd;
+pub mod config;
 pub mod db;
 pub mod disk;
 mod hex_utils;

--- a/rust/src/lightning.rs
+++ b/rust/src/lightning.rs
@@ -653,6 +653,7 @@ pub async fn connect_peer_if_necessary(
     .await
     {
         Some(connection_closed_future) => {
+            tracing::info!("Connected with {peer}");
             let mut connection_closed_future = Box::pin(connection_closed_future);
             loop {
                 match futures::poll!(&mut connection_closed_future) {

--- a/rust/src/offer.rs
+++ b/rust/src/offer.rs
@@ -1,11 +1,10 @@
+use crate::config::maker_endpoint;
 use anyhow::anyhow;
 use anyhow::bail;
 use anyhow::Result;
 use reqwest::StatusCode;
 use serde::Deserialize;
 use serde::Serialize;
-
-use crate::wallet::maker_endpoint;
 
 #[derive(Serialize, Deserialize, Debug)]
 pub struct Offer {
@@ -16,7 +15,7 @@ pub struct Offer {
 
 pub async fn get_offer() -> Result<Option<Offer>> {
     let client = reqwest::Client::builder()
-        .timeout(crate::wallet::TCP_TIMEOUT)
+        .timeout(crate::config::TCP_TIMEOUT)
         .build()?;
     let result = client.get(maker_endpoint() + "/api/offer").send().await;
     let response = match result {


### PR DESCRIPTION
Revamp configuration to pass NETWORK env variable from command line (both for
taker and maker).
In case it's not set, or it's invalid, it defaults to testnet.

Move all the config values to a dedicated module to clear the code.

For local development, I recommend to set `export NETWORK=regtest` in your
bashrc to preserve previous behaviour.