### PR TITLE
fix: Don't hang on splash screen if maker is unreachable

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -215,15 +215,16 @@ class _TenTenOneState extends State<TenTenOneApp> {
           .then((value) => FLog.info(text: "ldk node stopped."))
           .catchError((error) => FLog.error(text: "ldk stopped with an error", exception: error));
 
+      setState(() {
+        ready = true;
+      });
+
       // connect to the maker, this will not return unless there was an error.
       api.connect().then((value) => FLog.error(text: "Lost connection to the maker")).catchError(
           (error) =>
               FLog.error(text: "Lost connection to the maker with an error", exception: error));
 
       FLog.info(text: "TenTenOne is ready!");
-      setState(() {
-        ready = true;
-      });
     } on FfiException catch (error) {
       FLog.error(text: "Failed to initialise: Error: " + error.message, exception: error);
     } catch (error) {


### PR DESCRIPTION
Lack of maker should not prevent anyone from using the app as a regular
bitcoin/lightning wallet.

Show the splash screen until the wallet is initialised