### PR TITLE
Log `Maker is alive` on trace

### DIFF
--- a/rust/src/api.rs
+++ b/rust/src/api.rs
@@ -111,7 +111,7 @@ pub async fn connect() -> Result<()> {
 
         match result {
             Ok(_) => {
-                tracing::debug!("Maker is alive!");
+                tracing::trace!("Maker is alive!");
                 if !connected {
                     let result = wallet::connect().await;
                     match result {


### PR DESCRIPTION
This is super spammy in the logs so I think we should have it on `trace`. If needed the taker can be run on `trace` to see the log.