### PR TITLE
Fix open CFD functionality

### DIFF
--- a/rust/src/config.rs
+++ b/rust/src/config.rs
@@ -9,9 +9,6 @@ const MAINNET_ELECTRUM: &str = "ssl://blockstream.info:700";
 const TESTNET_ELECTRUM: &str = "ssl://blockstream.info:993";
 const REGTEST_ELECTRUM: &str = "tcp://localhost:50000";
 
-pub static MAINNET_MEMPOOL: &str = "https://mempool.space/api/v1";
-pub static TESTNET_MEMPOOL: &str = "https://mempool.space/testnet/api/v1";
-
 static REGTEST_MAKER_IP: &str = "127.0.0.1";
 static REGTEST_MAKER_PORT_HTTP: u64 = 8000;
 // Maker PK is derived from our checked in regtest maker seed

--- a/rust/src/lightning.rs
+++ b/rust/src/lightning.rs
@@ -335,9 +335,16 @@ pub fn setup(
     // Step 4: Initialize Persist
     let persister = Arc::new(FilesystemPersister::new(ldk_data_dir.clone()));
 
+    // TODO: Maybe we don't really need to have the transaction filter (this one
+    // was removed in ldk-example)
+    // Step 5: Initialize the Transaction Filter
+
+    // LightningWallet implements the Filter trait for us
+    let filter = lightning_wallet.clone();
+
     // Step 6: Initialize the ChainMonitor
     let chain_monitor: Arc<ChainMonitor> = Arc::new(chainmonitor::ChainMonitor::new(
-        None, // TODO: Consider re-enabling the filter (lightning_wallet.clone())
+        Some(filter.clone()),
         broadcaster.clone(),
         logger.clone(),
         fee_estimator.clone(),
@@ -420,10 +427,9 @@ pub fn setup(
 
     // Make sure our filter is initialized with all the txs and outputs
     // that we need to be watching based on our set of channel monitors
-    // TODO: Re-enable this if added filter
-    // for (_, monitor) in channelmonitors.iter() {
-    //     monitor.load_outputs_to_watch(&filter.clone());
-    // }
+    for (_, monitor) in channelmonitors.iter() {
+        monitor.load_outputs_to_watch(&filter.clone());
+    }
 
     // `Confirm` trait is not implemented on an individual ChannelMonitor
     // but on a tuple consisting of (channel_monitor, broadcaster, fee_estimator, logger)


### PR DESCRIPTION
Fixes #369.

Interestingly, reverting https://github.com/itchysats/10101/commit/38c09b25c8903e2aeb6831c637493f88e5731ff1 does the trick.

My theory is that the taker wasn't able to pick up the funding transaction because of the missing filter, so the channel would never be considered ready and the short channel ID would never be available when opening a CFD.