### PR TITLE
fix: Present sent off-chain payments as negative

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -264,9 +264,11 @@ class _TenTenOneState extends State<TenTenOneApp> {
       switch (e.flow) {
         case bridge_definitions.Flow.Inbound:
           type = PaymentType.receive;
+          amount = Amount(e.sats);
           break;
         case bridge_definitions.Flow.Outbound:
           type = PaymentType.send;
+          amount = Amount(-e.sats);
           break;
       }
       PaymentStatus status;


### PR DESCRIPTION
I have tested it with the app running, just forgot to add a screenshot (it displays a `-` instead :) )