### PR TITLE
fix: Skip syncing the wallet when sending to address

### DIFF
--- a/rust/src/wallet.rs
+++ b/rust/src/wallet.rs
@@ -248,8 +248,6 @@ impl Wallet {
     }
 
     pub fn send_to_address(&self, send_to: Address, amount: u64) -> Result<Txid> {
-        self.sync()?;
-
         let wallet = self.lightning.wallet.get_wallet()?;
 
         let estimated_fee_rate = self


### PR DESCRIPTION
Send to address is called from the open channel route and takes quite some time - letting the client timeout for the request and the channel fails to open.

Sync is already running every 10 seconds - so the wallet should anyways be up to date.

Hard to test since it's not reproducible locally, but I think this resolves #388 