### PR TITLE
Add sqlite support for storing lightning payments

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -271,13 +271,13 @@ class _TenTenOneState extends State<TenTenOneApp> {
       }
       PaymentStatus status;
       switch (e.status) {
-        case TransactionStatus.Failed:
+        case HTLCStatus.Failed:
           status = PaymentStatus.failed;
           break;
-        case TransactionStatus.Succeeded:
+        case HTLCStatus.Succeeded:
           status = PaymentStatus.finalized;
           break;
-        case TransactionStatus.Pending:
+        case HTLCStatus.Pending:
           status = PaymentStatus.pending;
           break;
       }

--- a/rust/migrations/20221128012310_add_payments.sql
+++ b/rust/migrations/20221128012310_add_payments.sql
@@ -1,0 +1,12 @@
+-- Add lightning payments table
+CREATE TABLE IF NOT EXISTS payments (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    payment_hash TEXT UNIQUE NOT NULL,
+    preimage TEXT,
+    secret TEXT,
+    htlc_status TEXT NOT NULL,
+    amount_msat INTEGER,
+    created INTEGER NOT NULL,
+    updated INTEGER NOT NULL
+);
+CREATE UNIQUE INDEX IF NOT EXISTS payment_hash ON payments (payment_hash);

--- a/rust/migrations/20221128012310_add_payments.sql
+++ b/rust/migrations/20221128012310_add_payments.sql
@@ -4,6 +4,7 @@ CREATE TABLE IF NOT EXISTS payments (
     payment_hash TEXT UNIQUE NOT NULL,
     preimage TEXT,
     secret TEXT,
+    flow TEXT NOT NULL,
     htlc_status TEXT NOT NULL,
     amount_msat INTEGER,
     created INTEGER NOT NULL,

--- a/rust/sqlx-data.json
+++ b/rust/sqlx-data.json
@@ -16,6 +16,11 @@
       ],
       "nullable": [
         false,
+        true,
+        true,
+        false,
+        true,
+        false,
         false
       ],
       "parameters": {

--- a/rust/sqlx-data.json
+++ b/rust/sqlx-data.json
@@ -1,5 +1,65 @@
 {
   "db": "SQLite",
+  "29a218881d08533780e614d4fcbe5028b9ab89f3074ed540af3d7d1f25c32df2": {
+    "describe": {
+      "columns": [
+        {
+          "name": "payment_hash",
+          "ordinal": 0,
+          "type_info": "Text"
+        },
+        {
+          "name": "preimage",
+          "ordinal": 1,
+          "type_info": "Text"
+        },
+        {
+          "name": "secret",
+          "ordinal": 2,
+          "type_info": "Text"
+        },
+        {
+          "name": "flow: crate::lightning::Flow",
+          "ordinal": 3,
+          "type_info": "Text"
+        },
+        {
+          "name": "status: crate::lightning::HTLCStatus",
+          "ordinal": 4,
+          "type_info": "Text"
+        },
+        {
+          "name": "amount_msat",
+          "ordinal": 5,
+          "type_info": "Int64"
+        },
+        {
+          "name": "updated",
+          "ordinal": 6,
+          "type_info": "Int64"
+        },
+        {
+          "name": "created",
+          "ordinal": 7,
+          "type_info": "Int64"
+        }
+      ],
+      "nullable": [
+        false,
+        true,
+        true,
+        false,
+        false,
+        true,
+        false,
+        false
+      ],
+      "parameters": {
+        "Right": 0
+      }
+    },
+    "query": "\n            select\n                payment_hash,\n                preimage,\n                secret,\n                flow as \"flow: crate::lightning::Flow\",\n                htlc_status as \"status: crate::lightning::HTLCStatus\",\n                amount_msat,\n                updated,\n                created\n            from\n                payments\n            "
+  },
   "2c6382b1b49584102d15338359bf36748a2d71fb36ab04cdf326cf25db610952": {
     "describe": {
       "columns": [
@@ -16,11 +76,6 @@
       ],
       "nullable": [
         false,
-        true,
-        true,
-        false,
-        true,
-        false,
         false
       ],
       "parameters": {
@@ -28,6 +83,16 @@
       }
     },
     "query": "\n            select\n                txid,\n                maker_amount\n            from\n                ignore_txid\n            order by id\n            "
+  },
+  "99af1eadda937c42ca9908fa6c106a19ebe1ffd66bdef7d9e69df9d1fcbd26bf": {
+    "describe": {
+      "columns": [],
+      "nullable": [],
+      "parameters": {
+        "Right": 3
+      }
+    },
+    "query": "\n        UPDATE payments\n        SET\n            htlc_status = $1, updated = $2\n        WHERE\n            payments.payment_hash = $3\n        "
   },
   "a1ce0920b9ba534467e45c3b1a53e2aefec6809308c213b9eb143c3e87221475": {
     "describe": {

--- a/rust/src/db.rs
+++ b/rust/src/db.rs
@@ -1,11 +1,19 @@
+use crate::hex_utils;
+use crate::lightning::HTLCStatus;
+use crate::lightning::MillisatAmount;
+use crate::lightning::PaymentInfo;
 use anyhow::anyhow;
 use anyhow::bail;
+use anyhow::ensure;
 use anyhow::Context;
 use anyhow::Result;
 use bdk::bitcoin::hashes::hex::FromHex;
 use bdk::bitcoin::hashes::hex::ToHex;
 use bdk::bitcoin::Txid;
 use futures::TryStreamExt;
+use lightning::ln::PaymentHash;
+use lightning::ln::PaymentPreimage;
+use lightning::ln::PaymentSecret;
 use sqlx::pool::PoolConnection;
 use sqlx::sqlite::SqliteConnectOptions;
 use sqlx::Sqlite;
@@ -19,6 +27,12 @@ pub type SqliteConnection = PoolConnection<Sqlite>;
 
 /// Wallet has to be managed by Rust as generics are not support by frb
 static DB: Storage<Mutex<SqlitePool>> = Storage::new();
+
+fn into_array(vec: Vec<u8>) -> [u8; 32] {
+    vec.as_slice()
+        .try_into()
+        .unwrap_or_else(|_| panic!("Expected a Vec of length {} but it was {}", 32, vec.len()))
+}
 
 pub async fn init_db(sqlite_path: &Path) -> Result<()> {
     tracing::debug!(?sqlite_path, "SQLite database will be stored on disk");
@@ -103,4 +117,203 @@ pub async fn insert_ignore_txid(txid: Txid, maker_amount: i64) -> Result<()> {
     tracing::info!("Successfully stored txid to be ignored");
 
     Ok(())
+}
+
+pub async fn insert_payment(payment: &PaymentInfo) -> Result<()> {
+    let mut conn = acquire().await?;
+
+    let PaymentInfo {
+        hash,
+        preimage,
+        secret,
+        status,
+        amt_msat,
+        created_timestamp,
+        updated_timestamp,
+    } = payment.clone();
+
+    let query_result = sqlx::query(
+        r#"
+        INSERT INTO payments (payment_hash, preimage, secret, htlc_status, amount_msat, created, updated)
+        VALUES ($1, $2, $3, $4, $5, $6, $7)
+        "#,
+    )
+    .bind(base64::encode(hash.0))
+    .bind(preimage.map(|x| base64::encode(x.0)))
+    .bind(secret.map(|x| base64::encode(x.0)))
+    .bind(status)
+        .bind(amt_msat.0.map(|msat| msat as i64))
+    .bind(created_timestamp as i64)
+    .bind(updated_timestamp as i64)
+    .execute(&mut conn)
+    .await?;
+
+    ensure!(
+        query_result.rows_affected() == 1,
+        format!("Failed to insert payment: {}", hex_utils::hex_str(&hash.0))
+    );
+    tracing::info!(
+        "Successfully stored new payment: {}",
+        hex_utils::hex_str(&hash.0)
+    );
+    Ok(())
+}
+
+pub async fn update_payment(payment_hash: PaymentHash, status: HTLCStatus) -> Result<()> {
+    let mut connection = acquire().await?;
+    let updated = time::OffsetDateTime::now_utc().unix_timestamp();
+    let hash = base64::encode(payment_hash.0);
+
+    let query_result = sqlx::query!(
+        r#"
+        UPDATE payments
+        SET
+            htlc_status = $1, updated = $2
+        WHERE
+            payments.payment_hash = $3
+        "#,
+        status,
+        updated,
+        hash,
+    )
+    .execute(&mut connection)
+    .await?;
+
+    ensure!(
+        query_result.rows_affected() == 1,
+        "Failed to update payment"
+    );
+
+    tracing::info!(
+        "Successfully updated payment: {}",
+        hex_utils::hex_str(&payment_hash.0)
+    );
+
+    Ok(())
+}
+
+pub async fn load_payments() -> Result<Vec<PaymentInfo>> {
+    let mut conn = acquire().await?;
+
+    let mut rows = sqlx::query!(
+        r#"
+            select
+                payment_hash,
+                preimage,
+                secret,
+                htlc_status as "status: crate::lightning::HTLCStatus",
+                amount_msat,
+                updated,
+                created
+            from
+                payments
+            "#
+    )
+    .fetch(&mut *conn);
+
+    let mut payments = Vec::new();
+
+    while let Some(row) = rows.try_next().await? {
+        let payment = PaymentInfo {
+            hash: PaymentHash(into_array(base64::decode(row.payment_hash).unwrap())),
+            preimage: row
+                .preimage
+                .map(|x| PaymentPreimage(into_array(base64::decode(x).unwrap()))),
+            secret: row
+                .secret
+                .map(|x| PaymentSecret(into_array(base64::decode(x).unwrap()))),
+            status: row.status,
+            amt_msat: row
+                .amount_msat
+                .map(|msats| MillisatAmount(Some(msats as u64)))
+                .unwrap_or(MillisatAmount(None)),
+            created_timestamp: row.created as u64,
+            updated_timestamp: row.updated as u64,
+        };
+        payments.push(payment);
+    }
+
+    Ok(payments)
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::lightning::MillisatAmount;
+    use bdk::wallet::time::get_timestamp;
+    use std::env::temp_dir;
+    use std::time::Duration;
+    use tracing::subscriber::DefaultGuard;
+    use tracing_subscriber::util::SubscriberInitExt;
+
+    use super::*;
+
+    fn dummy_payment() -> PaymentInfo {
+        PaymentInfo {
+            hash: PaymentHash([0u8; 32]),
+            preimage: None,
+            secret: None,
+            status: crate::lightning::HTLCStatus::Pending,
+            amt_msat: MillisatAmount(Some(100000)),
+            created_timestamp: get_timestamp(),
+            updated_timestamp: get_timestamp(),
+        }
+    }
+
+    pub fn init_tracing() -> DefaultGuard {
+        tracing_subscriber::fmt()
+            .with_env_filter("DEBUG")
+            .set_default()
+    }
+
+    async fn ensure_init_fresh_db() -> Result<()> {
+        if get_db().is_err() {
+            let sqlite_path = temp_dir().join("test.sqlite");
+            if sqlite_path.exists() {
+                std::fs::remove_file(sqlite_path.clone()).unwrap();
+            };
+            init_db(sqlite_path.as_path())
+                .await
+                .expect("DB to initialise ");
+        };
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_payments_db_storage() {
+        let _guard = init_tracing();
+        ensure_init_fresh_db().await.unwrap();
+        let payment = dummy_payment();
+        insert_payment(&payment).await.unwrap();
+
+        let payments = load_payments().await.unwrap();
+
+        assert_eq!(payments.len(), 1, "Only one payment got stored");
+        assert_eq!(
+            payments.first().unwrap(),
+            &payment,
+            "Stored and loaded payment do not match",
+        );
+
+        tokio::time::sleep(Duration::from_secs(1)).await; // so updated time changes
+
+        update_payment(payment.hash, HTLCStatus::Succeeded)
+            .await
+            .unwrap();
+
+        let updated_payment = {
+            let payments = load_payments().await.unwrap();
+            payments.first().unwrap().clone()
+        };
+
+        assert_eq!(
+            updated_payment.status,
+            HTLCStatus::Succeeded,
+            "Status should have been updated"
+        );
+
+        assert_ne!(
+            updated_payment.created_timestamp,
+            updated_payment.updated_timestamp
+        );
+    }
 }

--- a/rust/src/wallet.rs
+++ b/rust/src/wallet.rs
@@ -401,7 +401,7 @@ pub fn get_lightning_history() -> Result<Vec<LightningTransaction>> {
             flow: Flow::Outbound,
             sats: Amount::from(payment_info.amt_msat.clone()).to_sat(),
             status: payment_info.status.clone().into(),
-            timestamp: payment_info.timestamp,
+            timestamp: payment_info.updated_timestamp,
         })
         .collect();
 
@@ -412,7 +412,7 @@ pub fn get_lightning_history() -> Result<Vec<LightningTransaction>> {
             flow: Flow::Inbound,
             sats: Amount::from(payment_info.amt_msat.clone()).to_sat(),
             status: payment_info.status.clone().into(),
-            timestamp: payment_info.timestamp,
+            timestamp: payment_info.updated_timestamp,
         })
         .collect::<Vec<_>>();
 

--- a/rust/src/wallet.rs
+++ b/rust/src/wallet.rs
@@ -400,7 +400,7 @@ pub fn get_lightning_history() -> Result<Vec<LightningTransaction>> {
             tx_type: LightningTransactionType::Payment,
             flow: Flow::Outbound,
             sats: Amount::from(payment_info.amt_msat.clone()).to_sat(),
-            status: payment_info.status.clone().into(),
+            status: payment_info.status.clone(),
             timestamp: payment_info.updated_timestamp,
         })
         .collect();
@@ -411,7 +411,7 @@ pub fn get_lightning_history() -> Result<Vec<LightningTransaction>> {
             tx_type: LightningTransactionType::Payment,
             flow: Flow::Inbound,
             sats: Amount::from(payment_info.amt_msat.clone()).to_sat(),
-            status: payment_info.status.clone().into(),
+            status: payment_info.status.clone(),
             timestamp: payment_info.updated_timestamp,
         })
         .collect::<Vec<_>>();
@@ -567,28 +567,11 @@ pub struct LightningTransaction {
     pub tx_type: LightningTransactionType,
     pub flow: Flow,
     pub sats: u64,
-    pub status: TransactionStatus,
+    pub status: HTLCStatus,
     pub timestamp: u64,
 }
 
 pub enum Flow {
     Inbound,
     Outbound,
-}
-
-// TODO: Remove this? Seems to be exactly the same as HTLCStatus
-pub enum TransactionStatus {
-    Failed,
-    Succeeded,
-    Pending,
-}
-
-impl From<HTLCStatus> for TransactionStatus {
-    fn from(s: HTLCStatus) -> Self {
-        match s {
-            HTLCStatus::Succeeded => TransactionStatus::Succeeded,
-            HTLCStatus::Failed => TransactionStatus::Failed,
-            HTLCStatus::Pending => TransactionStatus::Pending,
-        }
-    }
 }

--- a/rust/src/wallet.rs
+++ b/rust/src/wallet.rs
@@ -5,6 +5,7 @@ use crate::config::TCP_TIMEOUT;
 use crate::db;
 use crate::lightning;
 use crate::lightning::ChannelManager;
+use crate::lightning::Flow;
 use crate::lightning::HTLCStatus;
 use crate::lightning::LightningSystem;
 use crate::lightning::NodeInfo;
@@ -569,9 +570,4 @@ pub struct LightningTransaction {
     pub sats: u64,
     pub status: HTLCStatus,
     pub timestamp: u64,
-}
-
-pub enum Flow {
-    Inbound,
-    Outbound,
 }


### PR DESCRIPTION
note: this is just the insert/load API with tests, adding it now to avoid trouble rebasing later (and to spark a conversation whether we should use one or two tables (inbound / outbound payments)