### PR TITLE
Fix condition to disable the submit button if an error is present

### DIFF
--- a/lib/cfd_trading/cfd_order_confirmation.dart
+++ b/lib/cfd_trading/cfd_order_confirmation.dart
@@ -130,7 +130,7 @@ class _CfdOrderConfirmationState extends State<CfdOrderConfirmation> {
                       await openCfd(order, cfdTradingChangeNotifier);
                     },
                     label: 'Confirm',
-                    isButtonDisabled: channelError == null,
+                    isButtonDisabled: channelError != null,
                   ),
                 )),
           ]),


### PR DESCRIPTION
An error is present if `channelError` is not null.