### PR TITLE
Sync the maker with the blockchain periodically

### DIFF
--- a/maker/src/main.rs
+++ b/maker/src/main.rs
@@ -47,6 +47,11 @@ async fn main() -> Result<()> {
 
         loop {
             let started = Instant::now();
+
+            if let Err(e) = wallet::sync() {
+                tracing::error!("Wallet sync failed: {e:#}");
+            }
+
             let wallet_result = wallet::get_balance();
             let duration = started.elapsed();
             let sync_time_in_seconds = duration.as_secs();


### PR DESCRIPTION
We split syncing from getting the balance in patch f7e300dbb31fca4f1aadc1504cc711365220909e. This was okay for the taker, who still syncs periodically.

On the other hand, the maker was only calling `get_balance` periodically. Therefore, the UTXO set was no longer being updated.