### PR TITLE
Align safe area

### DIFF
--- a/lib/cfd_trading/cfd_trading.dart
+++ b/lib/cfd_trading/cfd_trading.dart
@@ -32,40 +32,39 @@ class _CfdTradingState extends State<CfdTrading> {
 
     const balanceSelector = BalanceSelector.lightning;
 
-    return SafeArea(
-      child: Scaffold(
-          appBar: PreferredSize(
-              child: const AppBarWithBalance(balanceSelector: balanceSelector),
-              preferredSize: Size.fromHeight(balanceSelector.preferredHeight)),
-          drawer: const Menu(),
-          body: _pages.elementAt(cfdTradingService.selectedIndex),
-          bottomNavigationBar: BottomNavigationBar(
-            items: const <BottomNavigationBarItem>[
-              BottomNavigationBarItem(
-                icon: Icon(Icons.handshake),
-                label: 'Trade',
-              ),
-              BottomNavigationBarItem(
-                icon: Icon(Icons.format_list_bulleted_sharp),
-                label: 'Positions',
-              ),
-              BottomNavigationBarItem(
-                icon: Icon(Icons.candlestick_chart_sharp),
-                label: 'Market',
-              ),
-            ],
-            currentIndex: cfdTradingService.selectedIndex,
-            selectedItemColor: Theme.of(context).colorScheme.primary,
-            onTap: (index) {
-              setState(() {
-                // setting the selected index should be sufficient but for some reason
-                // this is not triggering a rebuild even though the cfd trading state
-                // is watched. A manual re-rendering is triggered through the setState
-                // hook.
-                cfdTradingService.selectedIndex = index;
-              });
-            },
-          )),
+    return Scaffold(
+      appBar: PreferredSize(
+          child: const SafeArea(child: AppBarWithBalance(balanceSelector: balanceSelector)),
+          preferredSize: Size.fromHeight(balanceSelector.preferredHeight)),
+      drawer: const Menu(),
+      body: SafeArea(child: _pages.elementAt(cfdTradingService.selectedIndex)),
+      bottomNavigationBar: BottomNavigationBar(
+        items: const <BottomNavigationBarItem>[
+          BottomNavigationBarItem(
+            icon: Icon(Icons.handshake),
+            label: 'Trade',
+          ),
+          BottomNavigationBarItem(
+            icon: Icon(Icons.format_list_bulleted_sharp),
+            label: 'Positions',
+          ),
+          BottomNavigationBarItem(
+            icon: Icon(Icons.candlestick_chart_sharp),
+            label: 'Market',
+          ),
+        ],
+        currentIndex: cfdTradingService.selectedIndex,
+        selectedItemColor: Theme.of(context).colorScheme.primary,
+        onTap: (index) {
+          setState(() {
+            // setting the selected index should be sufficient but for some reason
+            // this is not triggering a rebuild even though the cfd trading state
+            // is watched. A manual re-rendering is triggered through the setState
+            // hook.
+            cfdTradingService.selectedIndex = index;
+          });
+        },
+      ),
     );
   }
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 
 import 'package:f_logs/f_logs.dart';
 import 'package:flutter/foundation.dart' as foundation;
+import 'package:flutter/services.dart';
 import 'package:flutter_native_splash/flutter_native_splash.dart';
 import 'package:path_provider/path_provider.dart';
 import 'package:flutter/material.dart';
@@ -104,6 +105,7 @@ class _TenTenOneState extends State<TenTenOneApp> {
           ),
           appBarTheme: const AppBarTheme(
             foregroundColor: Colors.white,
+            systemOverlayStyle: SystemUiOverlayStyle.dark,
           )),
       routerConfig: _router,
     );

--- a/lib/service_placeholders.dart
+++ b/lib/service_placeholders.dart
@@ -16,26 +16,25 @@ class ServicePlaceholder extends StatelessWidget {
   Widget build(BuildContext context) {
     const balanceSelector = BalanceSelector.lightning;
 
-    return SafeArea(
-      child: Scaffold(
+    return Scaffold(
         drawer: const Menu(),
         appBar: PreferredSize(
             child: const AppBarWithBalance(balanceSelector: balanceSelector),
             preferredSize: Size.fromHeight(balanceSelector.preferredHeight)),
-        body: Padding(
-          padding: const EdgeInsets.all(20.0),
-          child: Center(
-            child: Column(
-              children: [
-                SizedBox(height: 40, child: Icon(service.icon)),
-                Text(service.label),
-                const Divider(),
-                Text(description)
-              ],
+        body: SafeArea(
+          child: Padding(
+            padding: const EdgeInsets.all(20.0),
+            child: Center(
+              child: Column(
+                children: [
+                  SizedBox(height: 40, child: Icon(service.icon)),
+                  Text(service.label),
+                  const Divider(),
+                  Text(description)
+                ],
+              ),
             ),
           ),
-        ),
-      ),
-    );
+        ));
   }
 }

--- a/lib/wallet/wallet.dart
+++ b/lib/wallet/wallet.dart
@@ -7,8 +7,6 @@ import 'package:ten_ten_one/wallet/wallet_dashboard.dart';
 import 'package:ten_ten_one/wallet/wallet_lightning.dart';
 
 class Wallet extends StatefulWidget {
-  static const route = '/trading';
-
   const Wallet({Key? key}) : super(key: key);
 
   @override
@@ -28,7 +26,7 @@ class _WalletState extends State<Wallet> {
 
     return Scaffold(
         drawer: const Menu(),
-        body: _pages.elementAt(walletChangeNotifier.selectedIndex),
+        body: SafeArea(child: _pages.elementAt(walletChangeNotifier.selectedIndex)),
         bottomNavigationBar: BottomNavigationBar(
           items: const <BottomNavigationBarItem>[
             BottomNavigationBarItem(

--- a/lib/wallet/wallet_bitcoin.dart
+++ b/lib/wallet/wallet_bitcoin.dart
@@ -44,42 +44,41 @@ class _WalletBitcoinState extends State<WalletBitcoin> {
 
     const balanceSelector = BalanceSelector.bitcoin;
 
-    return SafeArea(
-      child: Scaffold(
-        drawer: const Menu(),
-        appBar: PreferredSize(
-            child: const AppBarWithBalance(balanceSelector: balanceSelector),
-            preferredSize: Size.fromHeight(balanceSelector.preferredHeight)),
-        body: ListView(padding: const EdgeInsets.only(left: 25, right: 25), children: widgets),
-        floatingActionButton: SpeedDial(
-          icon: Icons.import_export,
-          iconTheme: const IconThemeData(size: 35),
-          activeIcon: Icons.close,
-          activeBackgroundColor: Colors.grey,
-          activeForegroundColor: Colors.white,
-          buttonSize: const Size(56.0, 56.0),
-          visible: true,
-          closeManually: false,
-          curve: Curves.bounceIn,
-          overlayColor: Colors.black,
-          overlayOpacity: 0.5,
-          elevation: 8.0,
-          shape: const CircleBorder(),
-          children: [
-            SpeedDialChild(
-              child: const Icon(Icons.download_sharp),
-              label: 'Receive',
-              labelStyle: const TextStyle(fontSize: 18.0),
-              onTap: () => GoRouter.of(context).go(ReceiveOnChain.route),
-            ),
-            SpeedDialChild(
-              child: const Icon(Icons.upload_sharp),
-              label: 'Send',
-              labelStyle: const TextStyle(fontSize: 18.0),
-              onTap: () => GoRouter.of(context).go(SendOnChain.route),
-            ),
-          ],
-        ),
+    return Scaffold(
+      drawer: const Menu(),
+      appBar: PreferredSize(
+          child: const AppBarWithBalance(balanceSelector: balanceSelector),
+          preferredSize: Size.fromHeight(balanceSelector.preferredHeight)),
+      body: SafeArea(
+          child: ListView(padding: const EdgeInsets.only(left: 25, right: 25), children: widgets)),
+      floatingActionButton: SpeedDial(
+        icon: Icons.import_export,
+        iconTheme: const IconThemeData(size: 35),
+        activeIcon: Icons.close,
+        activeBackgroundColor: Colors.grey,
+        activeForegroundColor: Colors.white,
+        buttonSize: const Size(56.0, 56.0),
+        visible: true,
+        closeManually: false,
+        curve: Curves.bounceIn,
+        overlayColor: Colors.black,
+        overlayOpacity: 0.5,
+        elevation: 8.0,
+        shape: const CircleBorder(),
+        children: [
+          SpeedDialChild(
+            child: const Icon(Icons.download_sharp),
+            label: 'Receive',
+            labelStyle: const TextStyle(fontSize: 18.0),
+            onTap: () => GoRouter.of(context).go(ReceiveOnChain.route),
+          ),
+          SpeedDialChild(
+            child: const Icon(Icons.upload_sharp),
+            label: 'Send',
+            labelStyle: const TextStyle(fontSize: 18.0),
+            onTap: () => GoRouter.of(context).go(SendOnChain.route),
+          ),
+        ],
       ),
     );
   }

--- a/lib/wallet/wallet_dashboard.dart
+++ b/lib/wallet/wallet_dashboard.dart
@@ -93,13 +93,13 @@ class _WalletDashboardState extends State<WalletDashboard> {
 
     const balanceSelector = BalanceSelector.both;
 
-    return SafeArea(
-      child: Scaffold(
-        drawer: const Menu(),
-        appBar: PreferredSize(
-            child: const AppBarWithBalance(balanceSelector: balanceSelector),
-            preferredSize: Size.fromHeight(balanceSelector.preferredHeight)),
-        body: ListView(padding: const EdgeInsets.only(left: 20, right: 20), children: widgets),
+    return Scaffold(
+      drawer: const Menu(),
+      appBar: PreferredSize(
+          child: const AppBarWithBalance(balanceSelector: balanceSelector),
+          preferredSize: Size.fromHeight(balanceSelector.preferredHeight)),
+      body: SafeArea(
+        child: ListView(padding: const EdgeInsets.only(left: 20, right: 20), children: widgets),
       ),
     );
   }

--- a/lib/wallet/wallet_lightning.dart
+++ b/lib/wallet/wallet_lightning.dart
@@ -64,48 +64,47 @@ class _WalletLightningState extends State<WalletLightning> {
                   type: AlertType.info)));
     }
 
-    return SafeArea(
-      child: Scaffold(
-        drawer: const Menu(),
-        appBar: PreferredSize(
-            child: const AppBarWithBalance(balanceSelector: balanceSelector),
-            preferredSize: Size.fromHeight(balanceSelector.preferredHeight)),
-        body: ListView(padding: const EdgeInsets.only(left: 25, right: 25), children: widgets),
-        floatingActionButton: SpeedDial(
-          icon: Icons.import_export,
-          iconTheme: const IconThemeData(size: 35),
-          activeIcon: Icons.close,
-          activeBackgroundColor: Colors.grey,
-          activeForegroundColor: Colors.white,
-          buttonSize: const Size(56.0, 56.0),
-          visible: !hasOpenCfds,
-          closeManually: false,
-          curve: Curves.bounceIn,
-          overlayColor: Colors.black,
-          overlayOpacity: 0.5,
-          elevation: 8.0,
-          shape: const CircleBorder(),
-          children: [
-            SpeedDialChild(
-              child: const Icon(Icons.link),
-              label: 'Close channel',
-              labelStyle: const TextStyle(fontSize: 18.0),
-              onTap: () => GoRouter.of(context).go(CloseChannel.route),
-            ),
-            SpeedDialChild(
-              child: const Icon(Icons.download_sharp),
-              label: 'Receive',
-              labelStyle: const TextStyle(fontSize: 18.0),
-              onTap: () => GoRouter.of(context).go(Receive.route),
-            ),
-            SpeedDialChild(
-              child: const Icon(Icons.upload_sharp),
-              label: 'Send',
-              labelStyle: const TextStyle(fontSize: 18.0),
-              onTap: () => GoRouter.of(context).go(Send.route),
-            ),
-          ],
-        ),
+    return Scaffold(
+      drawer: const Menu(),
+      appBar: PreferredSize(
+          child: const AppBarWithBalance(balanceSelector: balanceSelector),
+          preferredSize: Size.fromHeight(balanceSelector.preferredHeight)),
+      body: SafeArea(
+          child: ListView(padding: const EdgeInsets.only(left: 25, right: 25), children: widgets)),
+      floatingActionButton: SpeedDial(
+        icon: Icons.import_export,
+        iconTheme: const IconThemeData(size: 35),
+        activeIcon: Icons.close,
+        activeBackgroundColor: Colors.grey,
+        activeForegroundColor: Colors.white,
+        buttonSize: const Size(56.0, 56.0),
+        visible: !hasOpenCfds,
+        closeManually: false,
+        curve: Curves.bounceIn,
+        overlayColor: Colors.black,
+        overlayOpacity: 0.5,
+        elevation: 8.0,
+        shape: const CircleBorder(),
+        children: [
+          SpeedDialChild(
+            child: const Icon(Icons.link),
+            label: 'Close channel',
+            labelStyle: const TextStyle(fontSize: 18.0),
+            onTap: () => GoRouter.of(context).go(CloseChannel.route),
+          ),
+          SpeedDialChild(
+            child: const Icon(Icons.download_sharp),
+            label: 'Receive',
+            labelStyle: const TextStyle(fontSize: 18.0),
+            onTap: () => GoRouter.of(context).go(Receive.route),
+          ),
+          SpeedDialChild(
+            child: const Icon(Icons.upload_sharp),
+            label: 'Send',
+            labelStyle: const TextStyle(fontSize: 18.0),
+            onTap: () => GoRouter.of(context).go(Send.route),
+          ),
+        ],
       ),
     );
   }


### PR DESCRIPTION
Notes on setting `SystemUiOverlayStyle`:

I wanted to achieve that for the main screens we would use `SystemUiOverlayStyle.dark` and for the child screens (with blue app-bar on top) we would use `SystemUiOverlayStyle.light`, but unfortunately this is super tricky. I cold not get it work properly.
Unfortunately the behavior of setting the `SystemUiOverlayStyle` is not consistent with the docs - at least on the iOS emulator (I have to assume it will behave the same on iOS...).

I tried:

- Set `SystemUiOverlayStyle.dark` in `app_bar_with_balance.dart`'s `AppBar` - so that this one is always dark. But unfortunately whenever I navigate to a child screen (e.g. Receive, CFD Order, ...) this resets `SystemUiOverlayStyle.light`. When navigating back the status bar is white and not visible. I assumed this is because of the default value.
- I tried numerous approaches to get the balance / main screens to use `SystemUiOverlayStyle.dark`, but I always ran into the same problem. (I wrapped it with a Theme that sets it, I tried to wrap a Theme around the Scaffold rather than the balance, ...)
- I came to the conclusion that I have to change the default to `SystemUiOverlayStyle.dark`. This works, but only as long as I don't set it to `SystemUiOverlayStyle.light` in one of the child screens. If I do that it somehow overwrites the default (! - I think that's a bug...) and when navigating back the status bar is invisible because white again. 
- I tried to set the `SystemUiOverlayStyle` where we define the routes (would be a bit ugly, but at least in one place...), but that is tricky as well, because we would have to use `ShellRoutes` to achieve that and that blows up complexity...

I have a hunch that this is related to the theme set by the Swatch, but I already wasted enough time so...
I gave up and just accepted the solution where we set it to `dark` globally, but this does not look especially good on child screens 😅


![2022-11-29 22 20 15](https://user-images.githubusercontent.com/5557790/204516314-9a0819d1-626f-4d1c-a454-176f2384f0fa.gif)


