### PR TITLE
Take into account pending on-chain balance

### DIFF
--- a/lib/balance.dart
+++ b/lib/balance.dart
@@ -15,14 +15,29 @@ class Balance extends StatelessWidget {
   Widget build(BuildContext context) {
     return Consumer2<LightningBalance, BitcoinBalance>(
       builder: (context, lightningBalance, bitcoinBalance, child) {
-        var bitcoinBalanceDisplay = bitcoinBalance.amount.display(currency: Currency.sat);
+        var bitcoinBalanceTotalDisplay = bitcoinBalance.total().display(currency: Currency.sat);
+        var bitcoinBalanceConfirmedDisplay =
+            bitcoinBalance.confirmed.display(currency: Currency.sat);
+        var bitcoinBalancePendingDisplay = bitcoinBalance.pending().display(currency: Currency.sat);
+
         var lightningBalanceDisplay = lightningBalance.amount.display(currency: Currency.sat);
 
-        var bitcoinBalanceWidget = BalanceRow(
-            value: bitcoinBalanceDisplay.value,
-            unit: bitcoinBalanceDisplay.unit,
-            icon: Icons.link,
-            smaller: balanceSelector == BalanceSelector.both);
+        var bitcoinBalanceWidget = Tooltip(
+            richMessage: TextSpan(
+              text: 'Confirmed: ${bitcoinBalanceConfirmedDisplay.value} sats',
+              style: const TextStyle(fontWeight: FontWeight.bold),
+              children: [
+                TextSpan(
+                  text: '\nPending:      ${bitcoinBalancePendingDisplay.value} sats',
+                  style: const TextStyle(fontWeight: FontWeight.normal),
+                )
+              ],
+            ),
+            child: BalanceRow(
+                value: bitcoinBalanceTotalDisplay.value,
+                unit: bitcoinBalanceTotalDisplay.unit,
+                icon: Icons.link,
+                smaller: balanceSelector == BalanceSelector.both));
         var lightningBalanceWidget = BalanceRow(
             value: lightningBalanceDisplay.value,
             unit: lightningBalanceDisplay.unit,

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -255,7 +255,8 @@ Future<void> callSyncWithChain() async {
 Future<void> callGetBalances() async {
   try {
     final balance = await api.getBalance();
-    bitcoinBalance.update(Amount(balance.onChain.confirmed));
+    bitcoinBalance.update(Amount(balance.onChain.confirmed), Amount(balance.onChain.trustedPending),
+        Amount(balance.onChain.untrustedPending));
     lightningBalance.update(Amount(balance.offChain));
     FLog.trace(text: 'Successfully retrieved wallet balances');
   } catch (error) {

--- a/lib/models/balance_model.dart
+++ b/lib/models/balance_model.dart
@@ -11,10 +11,23 @@ class LightningBalance extends ChangeNotifier {
 }
 
 class BitcoinBalance extends ChangeNotifier {
-  Amount amount = Amount.zero;
+  Amount confirmed = Amount.zero;
+  Amount pendingInternal = Amount.zero;
+  Amount pendingExternal = Amount.zero;
 
-  void update(Amount amount) {
-    this.amount = amount;
+  Amount pending() {
+    return Amount(pendingExternal.asSats + pendingInternal.asSats);
+  }
+
+  Amount total() {
+    return Amount(confirmed.asSats + pending().asSats);
+  }
+
+  void update(Amount confirmed, Amount pendingInternal, Amount pendingExternal) {
+    this.confirmed = confirmed;
+    this.pendingInternal = pendingInternal;
+    this.pendingExternal = pendingExternal;
+
     super.notifyListeners();
   }
 }

--- a/lib/wallet/open_channel.dart
+++ b/lib/wallet/open_channel.dart
@@ -35,7 +35,7 @@ class _OpenChannelState extends State<OpenChannel> {
   void initState() {
     super.initState();
     final bitcoinBalance = context.read<BitcoinBalance>();
-    takerChannelAmount = bitcoinBalance.amount.asSats.clamp(0, OpenChannel.maxChannelAmount);
+    takerChannelAmount = bitcoinBalance.confirmed.asSats.clamp(0, OpenChannel.maxChannelAmount);
     controller.text = NumberFormat().format(takerChannelAmount);
     controller.addListener(() {
       setState(() {

--- a/lib/wallet/send_on_chain.dart
+++ b/lib/wallet/send_on_chain.dart
@@ -26,7 +26,7 @@ class _SendOnChainState extends State<SendOnChain> {
     super.initState();
 
     final bitcoinBalance = context.read<BitcoinBalance>();
-    amount = bitcoinBalance.amount.asSats;
+    amount = bitcoinBalance.confirmed.asSats;
   }
 
   @override

--- a/lib/wallet/wallet_dashboard.dart
+++ b/lib/wallet/wallet_dashboard.dart
@@ -52,7 +52,7 @@ class _WalletDashboardState extends State<WalletDashboard> {
           icon: const Icon(Icons.warning))));
     }
 
-    if (bitcoinBalance.amount.asSats == 0) {
+    if (bitcoinBalance.total().asSats == 0) {
       widgets.add(ActionCard(CardDetails(
           route: ReceiveOnChain.route,
           title: "Deposit Bitcoin",
@@ -61,7 +61,7 @@ class _WalletDashboardState extends State<WalletDashboard> {
           icon: const Icon(Icons.link))));
     }
 
-    if (bitcoinBalance.amount.asSats != 0 && lightningBalance.amount.asSats == 0) {
+    if (bitcoinBalance.total().asSats != 0 && lightningBalance.amount.asSats == 0) {
       widgets.add(ActionCard(CardDetails(
         route: OpenChannel.route,
         title: "Open Channel",

--- a/maker/src/main.rs
+++ b/maker/src/main.rs
@@ -87,6 +87,7 @@ async fn main() -> Result<()> {
                 routes::post_close_channel,
                 routes::post_open_channel,
                 routes::post_pay_invoice,
+                routes::post_send_to_address,
                 routes::get_new_invoice,
                 routes::get_wallet_details,
                 routes::get_channel_details,

--- a/maker/src/routes.rs
+++ b/maker/src/routes.rs
@@ -179,6 +179,23 @@ pub async fn post_open_channel(
     Ok(Json(OpenChannelResponse { funding_txid }))
 }
 
+#[rocket::post("/send/<address>/<amount>")]
+pub async fn post_send_to_address(address: String, amount: u64) -> Result<String, HttpApiProblem> {
+    let address = address.parse().map_err(|_| {
+        HttpApiProblem::new(StatusCode::BAD_REQUEST)
+            .title("Failed to send bitcoin to address")
+            .detail("Invalid address")
+    })?;
+
+    let txid = send_to_address(address, amount).map_err(|e| {
+        HttpApiProblem::new(StatusCode::INTERNAL_SERVER_ERROR)
+            .title("Failed to send bitcoin to address")
+            .detail(format!("{e:#}"))
+    })?;
+
+    Ok(txid.to_string())
+}
+
 #[rocket::post("/invoice/send/<invoice>")]
 pub async fn post_pay_invoice(invoice: String) -> Result<(), HttpApiProblem> {
     send_lightning_payment(&invoice).map_err(|e| {


### PR DESCRIPTION
Fixes https://github.com/itchysats/10101/issues/352.

Depending on the situation we make use of different values:

- The balance widget now displays the total balance by default, but on hover one can see a tooltip with the breakdown between confirmed and pending.
- We use the confirmed on-chain balance to determine how much bitcoin they user can use to either open a channel or send on-chain.
- We use the total on-chain balance to determine if the initial deposit-bitcoin card should be rendered or not.

![image](https://user-images.githubusercontent.com/9418575/204702872-1112d3c3-9c5d-4b58-a330-fa15b7cb56d1.png)

---

The first commit (https://github.com/itchysats/10101/commit/f56ab4895d9f2fbb20f4e36f00ccdc719cf970e4) was useful for testing so I decided to keep it around.