### PR TITLE
feat: Persist lightning payments in sqlite database

### DIFF
--- a/maker/src/routes.rs
+++ b/maker/src/routes.rs
@@ -181,7 +181,7 @@ pub async fn post_open_channel(
 
 #[rocket::post("/invoice/send/<invoice>")]
 pub async fn post_pay_invoice(invoice: String) -> Result<(), HttpApiProblem> {
-    send_lightning_payment(&invoice).map_err(|e| {
+    send_lightning_payment(&invoice).await.map_err(|e| {
         HttpApiProblem::new(StatusCode::INTERNAL_SERVER_ERROR)
             .title("Failed to pay lightning invoice")
             .detail(format!("{e:#}"))
@@ -191,11 +191,13 @@ pub async fn post_pay_invoice(invoice: String) -> Result<(), HttpApiProblem> {
 #[rocket::get("/invoice/create")]
 pub async fn get_new_invoice() -> Result<String, HttpApiProblem> {
     // FIXME: Hard-code the parameters for testing
-    create_invoice(10000, 6000, "maker's invoice".to_string()).map_err(|e| {
-        HttpApiProblem::new(StatusCode::INTERNAL_SERVER_ERROR)
-            .title("Failed to create lightning invoice")
-            .detail(format!("{e:#}"))
-    })
+    create_invoice(10000, 6000, "maker's invoice".to_string())
+        .await
+        .map_err(|e| {
+            HttpApiProblem::new(StatusCode::INTERNAL_SERVER_ERROR)
+                .title("Failed to create lightning invoice")
+                .detail(format!("{e:#}"))
+        })
 }
 
 #[derive(Serialize)]

--- a/rust/sqlx-data.json
+++ b/rust/sqlx-data.json
@@ -84,6 +84,16 @@
     },
     "query": "\n            select\n                txid,\n                maker_amount\n            from\n                ignore_txid\n            order by id\n            "
   },
+  "448e8280c76e9d2f5884e0dfa1d058e13ebfccf8687e1ade912cfbf59d70887e": {
+    "describe": {
+      "columns": [],
+      "nullable": [],
+      "parameters": {
+        "Right": 5
+      }
+    },
+    "query": "\n        UPDATE payments\n        SET\n            htlc_status = $1, updated = $2, preimage = $3, secret = $4\n        WHERE\n            payments.payment_hash = $5\n        "
+  },
   "99af1eadda937c42ca9908fa6c106a19ebe1ffd66bdef7d9e69df9d1fcbd26bf": {
     "describe": {
       "columns": [],

--- a/rust/src/api.rs
+++ b/rust/src/api.rs
@@ -176,8 +176,9 @@ pub async fn get_bitcoin_tx_history() -> Result<Vec<BitcoinTxHistoryItem>> {
     Ok(tx_history)
 }
 
-pub fn get_lightning_tx_history() -> Result<Vec<LightningTransaction>> {
-    wallet::get_lightning_history()
+#[tokio::main(flavor = "current_thread")]
+pub async fn get_lightning_tx_history() -> Result<Vec<LightningTransaction>> {
+    wallet::get_lightning_history().await
 }
 
 /// Initialise logging infrastructure for Rust
@@ -191,16 +192,18 @@ pub fn get_seed_phrase() -> Result<Vec<String>> {
     wallet::get_seed_phrase()
 }
 
-pub fn send_lightning_payment(invoice: String) -> Result<()> {
-    wallet::send_lightning_payment(&invoice)
+#[tokio::main(flavor = "current_thread")]
+pub async fn send_lightning_payment(invoice: String) -> Result<()> {
+    wallet::send_lightning_payment(&invoice).await
 }
 
-pub fn create_lightning_invoice(
+#[tokio::main(flavor = "current_thread")]
+pub async fn create_lightning_invoice(
     amount_sats: u64,
     expiry_secs: u32,
     description: String,
 ) -> Result<String> {
-    wallet::create_invoice(amount_sats, expiry_secs, description)
+    wallet::create_invoice(amount_sats, expiry_secs, description).await
 }
 
 // Note, this implementation has to be on the api level as otherwise it wouldn't be generated

--- a/rust/src/lightning.rs
+++ b/rust/src/lightning.rs
@@ -1,3 +1,7 @@
+use crate::db::insert_payment;
+use crate::db::load_payment;
+use crate::db::update_payment;
+use crate::db::PaymentNewInfo;
 use crate::disk;
 use crate::disk::FilesystemLogger;
 use crate::hex_utils;
@@ -68,8 +72,6 @@ use rand::Rng;
 use rand::RngCore;
 use serde::Serialize;
 use state::Storage;
-use std::collections::hash_map::Entry;
-use std::collections::HashMap;
 use std::fmt;
 use std::fmt::Display;
 use std::fmt::Formatter;
@@ -110,8 +112,6 @@ pub struct LightningSystem {
     pub keys_manager: Arc<KeysManager>,
     pub persister: Arc<FilesystemPersister>,
     pub gossip_sync: Arc<LdkGossipSync>,
-    pub inbound_payments: PaymentInfoStorage,
-    pub outbound_payments: PaymentInfoStorage,
     pub data_dir: PathBuf,
     pub network: Network,
 }
@@ -262,7 +262,27 @@ pub struct PaymentInfo {
     pub updated_timestamp: u64,
 }
 
-pub type PaymentInfoStorage = Arc<Mutex<HashMap<PaymentHash, PaymentInfo>>>;
+impl PaymentInfo {
+    pub fn new(
+        hash: PaymentHash,
+        preimage: Option<PaymentPreimage>,
+        secret: Option<PaymentSecret>,
+        flow: Flow,
+        status: HTLCStatus,
+        amt_msat: MillisatAmount,
+    ) -> Self {
+        Self {
+            hash,
+            preimage,
+            secret,
+            flow,
+            status,
+            amt_msat,
+            created_timestamp: get_timestamp(),
+            updated_timestamp: get_timestamp(),
+        }
+    }
+}
 
 pub(crate) type BdkLdkWallet = bdk_ldk::LightningWallet<ElectrumBlockchain, MemoryDatabase>;
 
@@ -513,9 +533,6 @@ pub fn setup(
         IgnoringMessageHandler {},
     ));
 
-    let inbound_payments: PaymentInfoStorage = Arc::new(Mutex::new(HashMap::new()));
-    let outbound_payments: PaymentInfoStorage = Arc::new(Mutex::new(HashMap::new()));
-
     let system = LightningSystem {
         wallet: lightning_wallet,
         chain_monitor,
@@ -527,8 +544,6 @@ pub fn setup(
         persister,
         gossip_sync,
         data_dir: Path::new(&ldk_data_dir).to_path_buf(),
-        inbound_payments,
-        outbound_payments,
         network,
     };
 
@@ -545,8 +560,6 @@ pub async fn run_ldk(system: &LightningSystem) -> Result<BackgroundProcessor> {
         wallet: system.wallet.clone(),
         network_graph: system.network_graph.clone(),
         keys_manager: system.keys_manager.clone(),
-        inbound_payments: system.inbound_payments.clone(),
-        outbound_payments: system.outbound_payments.clone(),
         network: system.network,
     };
 
@@ -676,12 +689,11 @@ async fn handle_ldk_events(
     wallet: Arc<BdkLdkWallet>,
     network_graph: &NetGraph,
     keys_manager: Arc<KeysManager>,
-    inbound_payments: PaymentInfoStorage,
-    outbound_payments: PaymentInfoStorage,
     network: Network,
     event: &Event,
 ) {
     tracing::debug!("Received {:?}", event);
+
     match event {
         Event::FundingGenerationReady {
             temporary_channel_id,
@@ -752,20 +764,18 @@ async fn handle_ldk_events(
             payment_hash,
             ..
         } => {
-            let mut payments = outbound_payments.lock().unwrap();
-            for (hash, payment) in payments.iter_mut() {
-                if *hash == *payment_hash {
-                    payment.preimage = Some(*payment_preimage);
-                    payment.status = HTLCStatus::Succeeded;
-                    tracing::info!(
-                        "EVENT: successfully sent payment of {} millisatoshis from \
-                                                                 payment hash {:?} with preimage {:?}",
-                        payment.amt_msat,
-                        hex_utils::hex_str(&payment_hash.0),
-                        hex_utils::hex_str(&payment_preimage.0)
-                    );
-                }
-            }
+            let new_info = Some(PaymentNewInfo {
+                preimage: Some(*payment_preimage),
+                secret: None,
+            });
+
+            match update_payment(payment_hash, HTLCStatus::Succeeded, new_info).await {
+                Ok(_) => tracing::info!(
+                    "EVENT: successfully sent payment  from payment hash {:?}",
+                    hex_utils::hex_str(&payment_hash.0),
+                ),
+                Err(e) => tracing::error!(?e),
+            };
         }
         Event::PaymentPathFailed {
             payment_hash,
@@ -796,10 +806,8 @@ async fn handle_ldk_events(
             };
             tracing::error!(payment_fail_msg);
 
-            let mut payments = outbound_payments.lock().unwrap();
-            if payments.contains_key(payment_hash) {
-                let payment = payments.get_mut(payment_hash).unwrap();
-                payment.status = HTLCStatus::Failed;
+            if let Err(e) = update_payment(payment_hash, HTLCStatus::Failed, None).await {
+                tracing::error!(?e);
             }
         }
         Event::PaymentForwarded {
@@ -925,17 +933,8 @@ async fn handle_ldk_events(
         } => {
             tracing::info!(?payment_id, ?payment_hash, "EVENT: Payment path failed",);
 
-            let mut payments = outbound_payments.lock().unwrap();
-            match payments.entry(*payment_hash) {
-                Entry::Occupied(mut e) => {
-                    let payment = e.get_mut();
-                    payment.status = HTLCStatus::Failed;
-                    payment.updated_timestamp = get_timestamp();
-                    // TODO: should we claim our funds here if the outbound payment failed?
-                }
-                Entry::Vacant(e) => {
-                    tracing::error!(?e, "Found vacant entry");
-                }
+            if let Err(e) = update_payment(payment_hash, HTLCStatus::Failed, None).await {
+                tracing::error!(?e, "Unknown payment");
             }
         }
         Event::PaymentPathSuccessful {
@@ -955,18 +954,9 @@ async fn handle_ldk_events(
             );
 
             if let Some(payment_hash) = payment_hash {
-                let mut payments = inbound_payments.lock().unwrap();
-                match payments.entry(*payment_hash) {
-                    Entry::Occupied(mut e) => {
-                        let payment = e.get_mut();
-                        payment.status = HTLCStatus::Succeeded;
-                        payment.updated_timestamp = get_timestamp();
-
-                        channel_manager.claim_funds(payment.preimage.unwrap());
-                    }
-                    Entry::Vacant(e) => {
-                        tracing::error!(?e, "Found vacant entry");
-                    }
+                match update_payment(payment_hash, HTLCStatus::Succeeded, None).await {
+                    Ok(payment) => channel_manager.claim_funds(payment.preimage.unwrap()),
+                    Err(e) => tracing::error!(?e, "Could not update payment"),
                 }
             } else {
                 tracing::error!(?payment_id, "no payment hash in successful payment path");
@@ -986,30 +976,36 @@ async fn handle_ldk_events(
                 PaymentPurpose::InvoicePayment {
                     payment_preimage,
                     payment_secret,
-                    ..
                 } => (*payment_preimage, Some(*payment_secret)),
                 PaymentPurpose::SpontaneousPayment(preimage) => (Some(*preimage), None),
             };
-            let mut payments = inbound_payments.lock().unwrap();
-            match payments.entry(*payment_hash) {
-                Entry::Occupied(mut e) => {
-                    let payment = e.get_mut();
-                    payment.status = HTLCStatus::Succeeded;
-                    payment.preimage = payment_preimage;
-                    payment.secret = payment_secret;
-                    payment.updated_timestamp = get_timestamp();
-                }
-                Entry::Vacant(e) => {
-                    e.insert(PaymentInfo {
-                        hash: *payment_hash,
+
+            if let Ok(payment) = load_payment(payment_hash).await {
+                if let Err(e) = update_payment(
+                    &payment.hash,
+                    HTLCStatus::Succeeded,
+                    Some(PaymentNewInfo {
                         preimage: payment_preimage,
                         secret: payment_secret,
-                        flow: Flow::Inbound,
-                        status: HTLCStatus::Succeeded,
-                        amt_msat: MillisatAmount(Some(*amount_msat)),
-                        created_timestamp: get_timestamp(),
-                        updated_timestamp: get_timestamp(),
-                    });
+                    }),
+                )
+                .await
+                {
+                    tracing::error!(?e);
+                }
+            } else {
+                let payment = PaymentInfo::new(
+                    *payment_hash,
+                    payment_preimage,
+                    payment_secret,
+                    Flow::Inbound,
+                    HTLCStatus::Succeeded,
+                    MillisatAmount(Some(*amount_msat)),
+                );
+                if let Err(e) = insert_payment(&payment).await {
+                    {
+                        tracing::error!(?e);
+                    }
                 }
             }
         }
@@ -1097,8 +1093,6 @@ pub struct BdkLdkEventHandler {
     wallet: Arc<BdkLdkWallet>,
     network_graph: Arc<NetGraph>,
     keys_manager: Arc<KeysManager>,
-    inbound_payments: PaymentInfoStorage,
-    outbound_payments: PaymentInfoStorage,
     network: Network,
 }
 
@@ -1109,15 +1103,13 @@ impl EventHandler for BdkLdkEventHandler {
             self.wallet.clone(),
             &self.network_graph,
             self.keys_manager.clone(),
-            self.inbound_payments.clone(),
-            self.outbound_payments.clone(),
             self.network,
             event,
         ));
     }
 }
 
-pub fn send_payment(invoice: &Invoice, outbound_payments: PaymentInfoStorage) -> Result<()> {
+pub async fn send_payment(invoice: &Invoice) -> Result<()> {
     let status = {
         let invoice_payer = INVOICE_PAYER
             .try_get()
@@ -1153,32 +1145,21 @@ pub fn send_payment(invoice: &Invoice, outbound_payments: PaymentInfoStorage) ->
             }
         }
     };
-    let payment_hash = PaymentHash((*invoice.payment_hash()).into_inner());
-    let payment_secret = Some(*invoice.payment_secret());
-
-    let mut payments = outbound_payments
-        .lock()
-        .map_err(|e| anyhow!("cannot get lock to outgoing payments: {e:#}"))?;
-    payments.insert(
-        payment_hash,
-        PaymentInfo {
-            hash: payment_hash,
-            preimage: None,
-            secret: payment_secret,
-            flow: Flow::Outbound,
-            status,
-            amt_msat: MillisatAmount(invoice.amount_milli_satoshis()),
-            updated_timestamp: get_timestamp(),
-            created_timestamp: get_timestamp(),
-        },
+    let payment = PaymentInfo::new(
+        PaymentHash((*invoice.payment_hash()).into_inner()),
+        None,
+        Some(*invoice.payment_secret()),
+        Flow::Outbound,
+        status,
+        MillisatAmount(invoice.amount_milli_satoshis()),
     );
+    insert_payment(&payment).await?;
     Ok(())
 }
 
 #[allow(clippy::too_many_arguments)]
-pub fn create_invoice(
+pub async fn create_invoice(
     amt_msat: u64,
-    inbound_payments: PaymentInfoStorage,
     channel_manager: Arc<ChannelManager>,
     keys_manager: Arc<KeysManager>,
     network: Network,
@@ -1186,9 +1167,6 @@ pub fn create_invoice(
     expiry_secs: u32,
     logger: Arc<disk::FilesystemLogger>,
 ) -> Result<String> {
-    let mut payments = inbound_payments
-        .lock()
-        .map_err(|e| anyhow!("could not acquire lock: {e:#}"))?;
     let currency = match network {
         Network::Bitcoin => Currency::Bitcoin,
         Network::Testnet => Currency::BitcoinTestnet,
@@ -1213,19 +1191,14 @@ pub fn create_invoice(
         }
     };
 
-    let payment_hash = PaymentHash((*invoice.payment_hash()).into_inner());
-    payments.insert(
-        payment_hash,
-        PaymentInfo {
-            hash: payment_hash,
-            preimage: None,
-            secret: Some(*invoice.payment_secret()),
-            status: HTLCStatus::Pending,
-            flow: Flow::Inbound,
-            amt_msat: MillisatAmount(Some(amt_msat)),
-            updated_timestamp: get_timestamp(),
-            created_timestamp: get_timestamp(),
-        },
+    let payment = PaymentInfo::new(
+        PaymentHash((*invoice.payment_hash()).into_inner()),
+        None,
+        Some(*invoice.payment_secret()),
+        Flow::Inbound,
+        HTLCStatus::Pending,
+        MillisatAmount(Some(amt_msat)),
     );
+    insert_payment(&payment).await?;
     Ok(invoice.to_string())
 }

--- a/rust/src/wallet.rs
+++ b/rust/src/wallet.rs
@@ -3,6 +3,7 @@ use crate::config::maker_endpoint;
 use crate::config::maker_peer_info;
 use crate::config::TCP_TIMEOUT;
 use crate::db;
+use crate::db::load_payments;
 use crate::lightning;
 use crate::lightning::ChannelManager;
 use crate::lightning::Flow;
@@ -293,30 +294,6 @@ impl Wallet {
         Ok(tx.txid())
     }
 
-    pub fn send_lightning_payment(&self, invoice: &Invoice) -> Result<()> {
-        lightning::send_payment(invoice, self.lightning.outbound_payments.clone())?;
-        Ok(())
-    }
-
-    pub fn create_invoice(
-        &self,
-        amount_sats: u64,
-        expiry_secs: u32,
-        description: String,
-    ) -> Result<String> {
-        let amount_msat = amount_sats * 1000;
-        lightning::create_invoice(
-            amount_msat,
-            self.lightning.inbound_payments.clone(),
-            self.lightning.channel_manager.clone(),
-            self.lightning.keys_manager.clone(),
-            self.lightning.network,
-            description,
-            expiry_secs,
-            self.lightning.logger.clone(),
-        )
-    }
-
     /// Fee recommendation in sats per vbyte.
     pub fn get_fee_recommendation(&self) -> Result<u32> {
         let fee_rate = self
@@ -386,39 +363,19 @@ pub fn get_channel_manager() -> Result<Arc<ChannelManager>> {
     Ok(get_wallet()?.get_channel_manager())
 }
 
-pub fn get_lightning_history() -> Result<Vec<LightningTransaction>> {
-    let (outbound, inbound) = {
-        let lightning = &get_wallet()?.lightning;
-        let x = (
-            lightning.outbound_payments.lock().unwrap().clone(),
-            lightning.inbound_payments.lock().unwrap().clone(),
-        );
-        x
-    };
-    let mut outbound = outbound
+pub async fn get_lightning_history() -> Result<Vec<LightningTransaction>> {
+    let payments = load_payments()
+        .await?
         .iter()
-        .map(|(_, payment_info)| LightningTransaction {
+        .map(|payment_info| LightningTransaction {
             tx_type: LightningTransactionType::Payment,
-            flow: Flow::Outbound,
+            flow: payment_info.flow.clone(),
             sats: Amount::from(payment_info.amt_msat.clone()).to_sat(),
             status: payment_info.status.clone(),
             timestamp: payment_info.updated_timestamp,
         })
         .collect();
-
-    let mut inbound = inbound
-        .iter()
-        .map(|(_, payment_info)| LightningTransaction {
-            tx_type: LightningTransactionType::Payment,
-            flow: Flow::Inbound,
-            sats: Amount::from(payment_info.amt_msat.clone()).to_sat(),
-            status: payment_info.status.clone(),
-            timestamp: payment_info.updated_timestamp,
-        })
-        .collect::<Vec<_>>();
-
-    inbound.append(&mut outbound);
-    Ok(inbound)
+    Ok(payments)
 }
 
 pub fn get_seed_phrase() -> Result<Vec<String>> {
@@ -426,9 +383,10 @@ pub fn get_seed_phrase() -> Result<Vec<String>> {
     Ok(seed_phrase)
 }
 
-pub fn send_lightning_payment(invoice: &str) -> Result<()> {
+pub async fn send_lightning_payment(invoice: &str) -> Result<()> {
     let invoice = Invoice::from_str(invoice).context("Could not parse Invoice string")?;
-    get_wallet()?.send_lightning_payment(&invoice)
+    lightning::send_payment(&invoice).await?;
+    Ok(())
 }
 
 #[derive(Serialize, Deserialize, Debug)]
@@ -547,8 +505,32 @@ pub fn get_node_info() -> Result<NodeInfo> {
     Ok(get_wallet()?.lightning.node_info())
 }
 
-pub fn create_invoice(amount_msat: u64, expiry_secs: u32, description: String) -> Result<String> {
-    get_wallet()?.create_invoice(amount_msat, expiry_secs, description)
+pub async fn create_invoice(
+    amount_sats: u64,
+    expiry_secs: u32,
+    description: String,
+) -> Result<String> {
+    let (channel_manager, keys_manager, network, logger) = {
+        let wallet = get_wallet()?;
+        (
+            wallet.lightning.channel_manager.clone(),
+            wallet.lightning.keys_manager.clone(),
+            wallet.lightning.network,
+            wallet.lightning.logger.clone(),
+        )
+    };
+
+    let amount_msat = amount_sats * 1000;
+    lightning::create_invoice(
+        amount_msat,
+        channel_manager,
+        keys_manager,
+        network,
+        description,
+        expiry_secs,
+        logger,
+    )
+    .await
 }
 
 pub fn get_fee_recommendation() -> Result<u32> {


### PR DESCRIPTION
Sending and creating invoices had to change to `async` due to sqlx async nature.