### PR TITLE
Revert "chore(deps): bump go_router from 5.1.5 to 5.2.0"

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -347,7 +347,7 @@ packages:
       name: go_router
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "5.2.0"
+    version: "5.1.5"
   graphs:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -13,7 +13,7 @@ dependencies:
   ffi: ^2.0.1
   provider: ^6.0.0
   intl: ^0.17.0
-  go_router: ^5.2.0
+  go_router: ^5.1.5
   flutter_svg: ^1.1.6
   f_logs: ^2.0.1
   flutter_speed_dial: ^6.2.0


### PR DESCRIPTION
Reverts itchysats/10101#422

fixes https://github.com/itchysats/10101/issues/441

Apparently we hit a regression bug that was already reported: https://github.com/flutter/flutter/issues/115962#issuecomment-1326560876

Note: I did go through the changelog before merging this and I did not see any indicator that we would run into trouble. Reverting for now, as there is no solution for `0.5.2` reported yet.

Note: Before I found the regression I actually gave replacing `/` with a specific `/wallet` route (and setting `/wallet` as initial route) a try, because in `/cfd-trading` and it's subroutes we did not have this problem even with `0.5.2`. But I experienced the same behavior.