### PR TITLE
Support connecting to both instances of the 10101 testnet maker

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,9 @@
 PROJECTNAME=$(shell basename "$(PWD)")
 # Default bitcoin network to run the project with `make`
 BITCOIN_NETWORK=regtest
+# Default 10101 testnet maker instance to run the project with `make`
+# It's only relevant if the dev uses `BITCOIN_NETWORK=testnet`
+MAKER_INSTANCE=main
 
 # Menu (visible if you type `make` or `make help`)
 .PHONY: help
@@ -89,7 +92,7 @@ gen: FORCE
 
 ## run: Run the app (need to pick the target, if no mobile emulator is running)
 run:
-	NETWORK=${BITCOIN_NETWORK} flutter run
+	NETWORK=${BITCOIN_NETWORK} TESTNET_MAKER_INSTANCE=${MAKER_INSTANCE} flutter run
 
 clippy: FORCE
 	cargo clippy --all-targets -- -D warnings

--- a/rust/src/config.rs
+++ b/rust/src/config.rs
@@ -16,10 +16,21 @@ const REGTEST_MAKER_PK: &str = "02cb6517193c466de0688b8b0386dbfb39d96c3844525c13
 
 const MAKER_PORT_LIGHTNING: u64 = 9045;
 
-const TESTNET_MAKER_IP: &str = "35.189.57.114"; // testnet.itchysats.network
-const TESTNET_MAKER_PORT_HTTP: u64 = 8888;
-// Maker PK logged in tentenone-maker testnet container
-const TESTNET_MAKER_PK: &str = "0244946473b7926c427be70925e8e99cafc3ea76dffe708e6cba8896576cf0b14d";
+/// IP corresponding to the domain `testnet.itchysats.network`.
+///
+/// _All_ 10101 testnet makers can be found behind this IP.
+const TESTNET_MAKER_IP: &str = "35.189.57.114";
+
+/// The port for the 10101 testnet maker running a stable release.
+///
+/// Alpha users should use this port.
+const TESTNET_STABLE_MAKER_PORT_HTTP: u64 = 8888;
+
+/// Public key of the 10101 maker running a stable release.
+///
+/// Alpha users should use this PK.
+const TESTNET_STABLE_MAKER_PK: &str =
+    "0244946473b7926c427be70925e8e99cafc3ea76dffe708e6cba8896576cf0b14d";
 
 pub const TCP_TIMEOUT: Duration = Duration::from_secs(10);
 
@@ -42,7 +53,9 @@ pub fn electrum_url() -> String {
 
 pub fn maker_pk() -> PublicKey {
     match network() {
-        Network::Testnet => TESTNET_MAKER_PK.parse().expect("Hard-coded PK to be valid"),
+        Network::Testnet => TESTNET_STABLE_MAKER_PK
+            .parse()
+            .expect("Hard-coded PK to be valid"),
         Network::Regtest => REGTEST_MAKER_PK.parse().expect("Hard-coded PK to be valid"),
         Network::Signet => todo!(),
         Network::Bitcoin => todo!(),
@@ -61,7 +74,7 @@ fn maker_ip() -> String {
 fn maker_port_http() -> u64 {
     match network() {
         Network::Bitcoin => todo!(),
-        Network::Testnet => TESTNET_MAKER_PORT_HTTP,
+        Network::Testnet => TESTNET_STABLE_MAKER_PORT_HTTP,
         Network::Signet => todo!(),
         Network::Regtest => REGTEST_MAKER_PORT_HTTP,
     }

--- a/rust/src/config.rs
+++ b/rust/src/config.rs
@@ -9,21 +9,19 @@ const MAINNET_ELECTRUM: &str = "ssl://blockstream.info:700";
 const TESTNET_ELECTRUM: &str = "ssl://blockstream.info:993";
 const REGTEST_ELECTRUM: &str = "tcp://localhost:50000";
 
-static REGTEST_MAKER_IP: &str = "127.0.0.1";
-static REGTEST_MAKER_PORT_HTTP: u64 = 8000;
+const REGTEST_MAKER_IP: &str = "127.0.0.1";
+const REGTEST_MAKER_PORT_HTTP: u64 = 8000;
 // Maker PK is derived from our checked in regtest maker seed
-static REGTEST_MAKER_PK: &str =
-    "02cb6517193c466de0688b8b0386dbfb39d96c3844525c1315d44bd8e108c08bc1";
+const REGTEST_MAKER_PK: &str = "02cb6517193c466de0688b8b0386dbfb39d96c3844525c1315d44bd8e108c08bc1";
 
-static MAKER_PORT_LIGHTNING: u64 = 9045;
+const MAKER_PORT_LIGHTNING: u64 = 9045;
 
-static TESTNET_MAKER_IP: &str = "35.189.57.114"; // testnet.itchysats.network
-static TESTNET_MAKER_PORT_HTTP: u64 = 8888;
+const TESTNET_MAKER_IP: &str = "35.189.57.114"; // testnet.itchysats.network
+const TESTNET_MAKER_PORT_HTTP: u64 = 8888;
 // Maker PK logged in tentenone-maker testnet container
-static TESTNET_MAKER_PK: &str =
-    "0244946473b7926c427be70925e8e99cafc3ea76dffe708e6cba8896576cf0b14d";
+const TESTNET_MAKER_PK: &str = "0244946473b7926c427be70925e8e99cafc3ea76dffe708e6cba8896576cf0b14d";
 
-pub static TCP_TIMEOUT: Duration = Duration::from_secs(10);
+pub const TCP_TIMEOUT: Duration = Duration::from_secs(10);
 
 /// Network the app is running
 ///


### PR DESCRIPTION
Fixes #438.

By default, taker app users will connect to the instance that runs the "stable" release.

By default, devs who run `NETWORK=testnet make run` or similar will connect to the instance that tracks `main`.

Devs will be able to connect to the stable version by specifying a value for the new environment variable e.g. 

```
NETWORK=testnet TESTNET_MAKER_INSTANCE=stable flutter run
```