### PR TITLE
feat: Add feedback button

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -13,6 +13,13 @@
     <uses-permission
         android:name="android.permission.WAKE_LOCK" />
 
+    <queries>
+        <intent>
+            <action android:name="android.intent.action.SENDTO" />
+            <data android:scheme="mailto" />
+        </intent>
+    </queries>
+
    <!-- NOTE extractNativeLibs is optional; only to have a better backtrace in debug mode. https://github.com/rust-lang/backtrace-rs/issues/442#issuecomment-942279097 -->
    <application
         android:label="10101"

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -1,38 +1,50 @@
 PODS:
   - Flutter (1.0.0)
+  - flutter_email_sender (0.0.1):
+    - Flutter
   - flutter_native_splash (0.0.1):
     - Flutter
   - integration_test (0.0.1):
     - Flutter
   - path_provider_ios (0.0.1):
     - Flutter
+  - url_launcher_ios (0.0.1):
+    - Flutter
   - webview_flutter_wkwebview (0.0.1):
     - Flutter
 
 DEPENDENCIES:
   - Flutter (from `Flutter`)
+  - flutter_email_sender (from `.symlinks/plugins/flutter_email_sender/ios`)
   - flutter_native_splash (from `.symlinks/plugins/flutter_native_splash/ios`)
   - integration_test (from `.symlinks/plugins/integration_test/ios`)
   - path_provider_ios (from `.symlinks/plugins/path_provider_ios/ios`)
+  - url_launcher_ios (from `.symlinks/plugins/url_launcher_ios/ios`)
   - webview_flutter_wkwebview (from `.symlinks/plugins/webview_flutter_wkwebview/ios`)
 
 EXTERNAL SOURCES:
   Flutter:
     :path: Flutter
+  flutter_email_sender:
+    :path: ".symlinks/plugins/flutter_email_sender/ios"
   flutter_native_splash:
     :path: ".symlinks/plugins/flutter_native_splash/ios"
   integration_test:
     :path: ".symlinks/plugins/integration_test/ios"
   path_provider_ios:
     :path: ".symlinks/plugins/path_provider_ios/ios"
+  url_launcher_ios:
+    :path: ".symlinks/plugins/url_launcher_ios/ios"
   webview_flutter_wkwebview:
     :path: ".symlinks/plugins/webview_flutter_wkwebview/ios"
 
 SPEC CHECKSUMS:
   Flutter: f04841e97a9d0b0a8025694d0796dd46242b2854
+  flutter_email_sender: 02d7443217d8c41483223627972bfdc09f74276b
   flutter_native_splash: 52501b97d1c0a5f898d687f1646226c1f93c56ef
   integration_test: a1e7d09bd98eca2fc37aefd79d4f41ad37bdbbe5
   path_provider_ios: 14f3d2fd28c4fdb42f44e0f751d12861c43cee02
+  url_launcher_ios: 839c58cdb4279282219f5e248c3321761ff3c4de
   webview_flutter_wkwebview: b7e70ef1ddded7e69c796c7390ee74180182971f
 
 PODFILE CHECKSUM: ef19549a9bc3046e7bb7d2fab4d021637c0c58a3

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -1,4 +1,6 @@
 PODS:
+  - device_info_plus (0.0.1):
+    - Flutter
   - Flutter (1.0.0)
   - flutter_email_sender (0.0.1):
     - Flutter
@@ -14,6 +16,7 @@ PODS:
     - Flutter
 
 DEPENDENCIES:
+  - device_info_plus (from `.symlinks/plugins/device_info_plus/ios`)
   - Flutter (from `Flutter`)
   - flutter_email_sender (from `.symlinks/plugins/flutter_email_sender/ios`)
   - flutter_native_splash (from `.symlinks/plugins/flutter_native_splash/ios`)
@@ -23,6 +26,8 @@ DEPENDENCIES:
   - webview_flutter_wkwebview (from `.symlinks/plugins/webview_flutter_wkwebview/ios`)
 
 EXTERNAL SOURCES:
+  device_info_plus:
+    :path: ".symlinks/plugins/device_info_plus/ios"
   Flutter:
     :path: Flutter
   flutter_email_sender:
@@ -39,6 +44,7 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/webview_flutter_wkwebview/ios"
 
 SPEC CHECKSUMS:
+  device_info_plus: e5c5da33f982a436e103237c0c85f9031142abed
   Flutter: f04841e97a9d0b0a8025694d0796dd46242b2854
   flutter_email_sender: 02d7443217d8c41483223627972bfdc09f74276b
   flutter_native_splash: 52501b97d1c0a5f898d687f1646226c1f93c56ef

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 
 import 'package:f_logs/f_logs.dart';
+import 'package:feedback/feedback.dart';
 import 'package:flutter/foundation.dart' as foundation;
 import 'package:flutter/services.dart';
 import 'package:flutter_native_splash/flutter_native_splash.dart';
@@ -93,24 +94,26 @@ class _TenTenOneState extends State<TenTenOneApp> {
     if (ready) {
       FlutterNativeSplash.remove();
     }
-    return MaterialApp.router(
-      debugShowCheckedModeBanner: false,
-      title: 'TenTenOne',
-      theme: ThemeData(
-          primarySwatch: mainColor,
-          elevatedButtonTheme: ElevatedButtonThemeData(
-              style: ElevatedButton.styleFrom(
-                  foregroundColor: Colors.white,
-                  minimumSize: const Size(100, 50),
-                  textStyle: const TextStyle(fontSize: 16.0))),
-          floatingActionButtonTheme: const FloatingActionButtonThemeData(
-            foregroundColor: Colors.white,
-          ),
-          appBarTheme: const AppBarTheme(
-            foregroundColor: Colors.white,
-            systemOverlayStyle: SystemUiOverlayStyle.dark,
-          )),
-      routerConfig: _router,
+    return BetterFeedback(
+      child: MaterialApp.router(
+        debugShowCheckedModeBanner: false,
+        title: 'TenTenOne',
+        theme: ThemeData(
+            primarySwatch: mainColor,
+            elevatedButtonTheme: ElevatedButtonThemeData(
+                style: ElevatedButton.styleFrom(
+                    foregroundColor: Colors.white,
+                    minimumSize: const Size(100, 50),
+                    textStyle: const TextStyle(fontSize: 16.0))),
+            floatingActionButtonTheme: const FloatingActionButtonThemeData(
+              foregroundColor: Colors.white,
+            ),
+            appBarTheme: const AppBarTheme(
+              foregroundColor: Colors.white,
+              systemOverlayStyle: SystemUiOverlayStyle.dark,
+            )),
+        routerConfig: _router,
+      ),
     );
   }
 

--- a/lib/menu.dart
+++ b/lib/menu.dart
@@ -1,80 +1,96 @@
+import 'dart:io';
+
+import 'package:feedback/feedback.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 import 'package:go_router/go_router.dart';
 import 'package:ten_ten_one/models/service_model.dart';
+import 'package:ten_ten_one/utilities/feedback.dart';
 
 class Menu extends StatelessWidget {
   const Menu({Key? key}) : super(key: key);
 
   @override
   Widget build(BuildContext context) {
+    List<Widget> items = [
+      DrawerHeader(
+        decoration: const BoxDecoration(
+          color: Colors.white,
+        ),
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            SizedBox(
+              height: 60,
+              width: 60,
+              child: SvgPicture.asset("assets/10101_logo.svg"),
+            ),
+            const Text("One App - All things Bitcoin", style: TextStyle(fontSize: 16)),
+            Text(
+              "⚡️ Trading, Stacking & More",
+              style: TextStyle(fontSize: 14, color: Theme.of(context).colorScheme.primary),
+            )
+          ],
+        ),
+      ),
+      ListTile(
+        title: Text(ServiceGroup.wallet.label),
+        leading: Icon(ServiceGroup.wallet.icon),
+        onTap: () {
+          GoRouter.of(context).go("/");
+        },
+      ),
+      ListTile(
+        title: Text(Service.trade.label),
+        leading: Icon(Service.trade.icon),
+        onTap: () {
+          GoRouter.of(context).go(Service.trade.route);
+        },
+      ),
+      ExpansionTile(
+          title: Text(ServiceGroup.invest.label),
+          leading: Icon(ServiceGroup.invest.icon),
+          initiallyExpanded: true,
+          children: [
+            ListTile(
+              title: Text(Service.dca.label),
+              leading: Icon(Service.dca.icon),
+              onTap: () {
+                GoRouter.of(context).go(Service.dca.route);
+              },
+            ),
+            ListTile(
+              title: Text(Service.savings.label),
+              leading: Icon(Service.savings.icon),
+              onTap: () {
+                GoRouter.of(context).go(Service.savings.route);
+              },
+            ),
+          ]),
+      ListTile(
+        title: const Text("Settings"),
+        leading: const Icon(Icons.settings),
+        onTap: () {},
+      ),
+    ];
+
+    if (Platform.isAndroid || Platform.isIOS) {
+      items.add(ListTile(
+        title: const Text("Feedback"),
+        leading: const Icon(Icons.feedback_outlined),
+        onTap: () {
+          Navigator.pop(context);
+          BetterFeedback.of(context).show(submitFeedback);
+        },
+      ));
+    }
+
     return Drawer(
       child: ListView(
         // Important: Remove any padding from the ListView.
         padding: EdgeInsets.zero,
-        children: [
-          DrawerHeader(
-            decoration: const BoxDecoration(
-              color: Colors.white,
-            ),
-            child: Column(
-              mainAxisAlignment: MainAxisAlignment.center,
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                SizedBox(
-                  height: 60,
-                  width: 60,
-                  child: SvgPicture.asset("assets/10101_logo.svg"),
-                ),
-                const Text("One App - All things Bitcoin", style: TextStyle(fontSize: 16)),
-                Text(
-                  "⚡️ Trading, Stacking & More",
-                  style: TextStyle(fontSize: 14, color: Theme.of(context).colorScheme.primary),
-                )
-              ],
-            ),
-          ),
-          ListTile(
-            title: Text(ServiceGroup.wallet.label),
-            leading: Icon(ServiceGroup.wallet.icon),
-            onTap: () {
-              GoRouter.of(context).go("/");
-            },
-          ),
-          ListTile(
-            title: Text(Service.trade.label),
-            leading: Icon(Service.trade.icon),
-            onTap: () {
-              GoRouter.of(context).go(Service.trade.route);
-            },
-          ),
-          ExpansionTile(
-            title: Text(ServiceGroup.invest.label),
-            leading: Icon(ServiceGroup.invest.icon),
-            initiallyExpanded: true,
-            children: [
-              ListTile(
-                title: Text(Service.dca.label),
-                leading: Icon(Service.dca.icon),
-                onTap: () {
-                  GoRouter.of(context).go(Service.dca.route);
-                },
-              ),
-              ListTile(
-                title: Text(Service.savings.label),
-                leading: Icon(Service.savings.icon),
-                onTap: () {
-                  GoRouter.of(context).go(Service.savings.route);
-                },
-              ),
-            ],
-          ),
-          ListTile(
-            title: const Text("Settings"),
-            leading: const Icon(Icons.settings),
-            onTap: () {},
-          ),
-        ],
+        children: items,
       ),
     );
   }

--- a/lib/utilities/feedback.dart
+++ b/lib/utilities/feedback.dart
@@ -1,0 +1,44 @@
+import 'dart:io';
+import 'dart:typed_data';
+
+import 'package:device_info_plus/device_info_plus.dart';
+import 'package:f_logs/model/flog/flog.dart';
+import 'package:feedback/feedback.dart';
+import 'package:flutter_email_sender/flutter_email_sender.dart';
+import 'package:path_provider/path_provider.dart';
+
+Future<void> submitFeedback(UserFeedback feedback) async {
+  final screenshotFilePath = await writeImageToStorage(feedback.screenshot);
+  final logs = await FLog.exportLogs();
+
+  final deviceInfoPlugin = DeviceInfoPlugin();
+  String info = "";
+  if (Platform.isAndroid) {
+    final deviceInfo = await deviceInfoPlugin.androidInfo;
+    info = deviceInfo.model.toString() +
+        ", Android " +
+        deviceInfo.version.sdkInt.toString() +
+        ", Release: " +
+        deviceInfo.version.release;
+  } else {
+    final deviceInfo = await deviceInfoPlugin.iosInfo;
+    info = deviceInfo.name! + ", " + deviceInfo.systemName! + " " + deviceInfo.systemVersion!;
+  }
+
+  final Email email = Email(
+    body: feedback.text + '\n\n----------\n' + info,
+    subject: '10101 Feedback',
+    recipients: ['10101-devs@coblox.tech'],
+    attachmentPaths: [screenshotFilePath, logs.path],
+    isHTML: false,
+  );
+  await FlutterEmailSender.send(email);
+}
+
+Future<String> writeImageToStorage(Uint8List feedbackScreenshot) async {
+  final Directory output = await getTemporaryDirectory();
+  final String screenshotFilePath = '${output.path}/feedback.png';
+  final File screenshotFile = File(screenshotFilePath);
+  await screenshotFile.writeAsBytes(feedbackScreenshot);
+  return screenshotFilePath;
+}

--- a/lib/wallet/wallet_dashboard.dart
+++ b/lib/wallet/wallet_dashboard.dart
@@ -1,5 +1,10 @@
+import 'dart:io';
+import 'dart:typed_data';
+
 import 'package:f_logs/f_logs.dart';
+import 'package:feedback/feedback.dart';
 import 'package:flutter/material.dart';
+import 'package:path_provider/path_provider.dart';
 import 'package:provider/provider.dart';
 import 'package:go_router/go_router.dart';
 import 'package:ten_ten_one/balance.dart';
@@ -13,6 +18,7 @@ import 'package:ten_ten_one/wallet/fund_wallet_on_chain.dart';
 import 'package:ten_ten_one/wallet/payment_history_list_item.dart';
 import 'package:ten_ten_one/wallet/seed.dart';
 import 'package:ten_ten_one/wallet/service_card.dart';
+import 'package:flutter_email_sender/flutter_email_sender.dart';
 
 import 'package:ten_ten_one/menu.dart';
 import 'package:ten_ten_one/app_bar_with_balance.dart';
@@ -92,6 +98,31 @@ class _WalletDashboardState extends State<WalletDashboard> {
     );
 
     widgets.add(paymentHistoryList);
+    if (Platform.isAndroid || Platform.isIOS) {
+      widgets.add(const SizedBox(height: 10));
+      widgets.add(OutlinedButton(
+        style: OutlinedButton.styleFrom(
+            minimumSize: const Size(20, 50),
+            side: BorderSide(width: 1.0, color: Theme.of(context).primaryColor)),
+        child: const Text('Provide feedback'),
+        onPressed: () {
+          BetterFeedback.of(context).show((feedback) async {
+            final screenshotFilePath = await writeImageToStorage(feedback.screenshot);
+            final logs = await FLog.exportLogs();
+
+            final Email email = Email(
+              body: feedback.text,
+              subject: '10101 Feedback',
+              recipients: ['richard@coblox.tech'],
+              attachmentPaths: [screenshotFilePath, logs.path],
+              isHTML: false,
+            );
+            await FlutterEmailSender.send(email);
+          });
+        },
+      ));
+      widgets.add(const SizedBox(height: 10));
+    }
 
     const balanceSelector = BalanceSelector.both;
 
@@ -105,6 +136,14 @@ class _WalletDashboardState extends State<WalletDashboard> {
                 onRefresh: _pullRefresh,
                 child: ListView(
                     padding: const EdgeInsets.only(left: 20, right: 20), children: widgets))));
+  }
+
+  Future<String> writeImageToStorage(Uint8List feedbackScreenshot) async {
+    final Directory output = await getTemporaryDirectory();
+    final String screenshotFilePath = '${output.path}/feedback.png';
+    final File screenshotFile = File(screenshotFilePath);
+    await screenshotFile.writeAsBytes(feedbackScreenshot);
+    return screenshotFilePath;
   }
 
   Future<void> _pullRefresh() async {

--- a/lib/wallet/wallet_dashboard.dart
+++ b/lib/wallet/wallet_dashboard.dart
@@ -19,6 +19,7 @@ import 'package:ten_ten_one/wallet/payment_history_list_item.dart';
 import 'package:ten_ten_one/wallet/seed.dart';
 import 'package:ten_ten_one/wallet/service_card.dart';
 import 'package:flutter_email_sender/flutter_email_sender.dart';
+import 'package:device_info_plus/device_info_plus.dart';
 
 import 'package:ten_ten_one/menu.dart';
 import 'package:ten_ten_one/app_bar_with_balance.dart';
@@ -98,7 +99,7 @@ class _WalletDashboardState extends State<WalletDashboard> {
     );
 
     widgets.add(paymentHistoryList);
-    if (Platform.isAndroid || Platform.isIOS) {
+    if (Platform.isAndroid || Platform.isIOS || true) {
       widgets.add(const SizedBox(height: 10));
       widgets.add(OutlinedButton(
         style: OutlinedButton.styleFrom(
@@ -110,8 +111,26 @@ class _WalletDashboardState extends State<WalletDashboard> {
             final screenshotFilePath = await writeImageToStorage(feedback.screenshot);
             final logs = await FLog.exportLogs();
 
+            final deviceInfoPlugin = DeviceInfoPlugin();
+            String info = "";
+            if (Platform.isAndroid) {
+              final deviceInfo = await deviceInfoPlugin.androidInfo;
+              info = deviceInfo.model.toString() +
+                  ", Android " +
+                  deviceInfo.version.sdkInt.toString() +
+                  ", Release: " +
+                  deviceInfo.version.release;
+            } else {
+              final deviceInfo = await deviceInfoPlugin.iosInfo;
+              info = deviceInfo.name! +
+                  ", " +
+                  deviceInfo.systemName! +
+                  " " +
+                  deviceInfo.systemVersion!;
+            }
+
             final Email email = Email(
-              body: feedback.text,
+              body: feedback.text + '\n\n----------\n' + info,
               subject: '10101 Feedback',
               recipients: ['richard@coblox.tech'],
               attachmentPaths: [screenshotFilePath, logs.path],

--- a/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -5,10 +5,12 @@
 import FlutterMacOS
 import Foundation
 
+import device_info_plus
 import path_provider_macos
 import url_launcher_macos
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
+  DeviceInfoPlusMacosPlugin.register(with: registry.registrar(forPlugin: "DeviceInfoPlusMacosPlugin"))
   PathProviderPlugin.register(with: registry.registrar(forPlugin: "PathProviderPlugin"))
   UrlLauncherPlugin.register(with: registry.registrar(forPlugin: "UrlLauncherPlugin"))
 }

--- a/macos/Podfile.lock
+++ b/macos/Podfile.lock
@@ -1,4 +1,6 @@
 PODS:
+  - device_info_plus (0.0.1):
+    - FlutterMacOS
   - FlutterMacOS (1.0.0)
   - path_provider_macos (0.0.1):
     - FlutterMacOS
@@ -6,11 +8,14 @@ PODS:
     - FlutterMacOS
 
 DEPENDENCIES:
+  - device_info_plus (from `Flutter/ephemeral/.symlinks/plugins/device_info_plus/macos`)
   - FlutterMacOS (from `Flutter/ephemeral`)
   - path_provider_macos (from `Flutter/ephemeral/.symlinks/plugins/path_provider_macos/macos`)
   - url_launcher_macos (from `Flutter/ephemeral/.symlinks/plugins/url_launcher_macos/macos`)
 
 EXTERNAL SOURCES:
+  device_info_plus:
+    :path: Flutter/ephemeral/.symlinks/plugins/device_info_plus/macos
   FlutterMacOS:
     :path: Flutter/ephemeral
   path_provider_macos:
@@ -19,6 +24,7 @@ EXTERNAL SOURCES:
     :path: Flutter/ephemeral/.symlinks/plugins/url_launcher_macos/macos
 
 SPEC CHECKSUMS:
+  device_info_plus: 5401765fde0b8d062a2f8eb65510fb17e77cf07f
   FlutterMacOS: ae6af50a8ea7d6103d888583d46bd8328a7e9811
   path_provider_macos: 3c0c3b4b0d4a76d2bf989a913c2de869c5641a19
   url_launcher_macos: 597e05b8e514239626bcf4a850fcf9ef5c856ec3

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -211,6 +211,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.3.1"
+  feedback:
+    dependency: "direct main"
+    description:
+      name: feedback
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.5.0"
   ffi:
     dependency: "direct main"
     description:
@@ -249,6 +256,13 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  flutter_email_sender:
+    dependency: "direct main"
+    description:
+      name: flutter_email_sender
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "5.2.0"
   flutter_launcher_icons:
     dependency: "direct dev"
     description:
@@ -263,6 +277,11 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.0.4"
+  flutter_localizations:
+    dependency: transitive
+    description: flutter
+    source: sdk
+    version: "0.0.0"
   flutter_native_splash:
     dependency: "direct main"
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -197,6 +197,20 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "2.3.1"
+  device_info_plus:
+    dependency: "direct main"
+    description:
+      name: device_info_plus
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "8.0.0"
+  device_info_plus_platform_interface:
+    dependency: transitive
+    description:
+      name: device_info_plus_platform_interface
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "7.0.0"
   f_logs:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -27,6 +27,7 @@ dependencies:
   flutter_native_splash: ^2.2.16
   feedback: ^2.5.0
   flutter_email_sender: ^5.2.0
+  device_info_plus: ^8.0.0
 dev_dependencies:
   flutter_launcher_icons: ^0.11.0
   flutter_test:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -25,6 +25,8 @@ dependencies:
   qr_flutter: ^4.0.0
   webview_flutter_plus: ^0.3.0
   flutter_native_splash: ^2.2.16
+  feedback: ^2.5.0
+  flutter_email_sender: ^5.2.0
 dev_dependencies:
   flutter_launcher_icons: ^0.11.0
   flutter_test:


### PR DESCRIPTION
I found this pretty cool feedback package (https://pub.dev/packages/feedback), that will allow the user to draw on the screen, add a feedback and send his logs via email.

I guess we we will not use that on a major release, but to get feedback on a beta version, it's pretty useful.

Works on Android and ios (not couldn't test on ios, since the simulator does not come with an email client). Updating the text "What's wrong" is kind of possible, but really ugly through translations. I tried it, but stopped again as it wasn't worth it. If you are very much bothered about it feel free to create a follow up PR 🙈 .

I struggled a bit with where to put that button. I could think of the following.

1. always visible: but where, it shouldn't distract too much.
2. in the drawer: i guess pretty hidden and the user might not find it.
3. on the wallet dashboard: visible at the beginning but moves out of sight the more the app is used. The user should still know that it's there though.

resolves #105 
resolves #414 

![feedback](https://user-images.githubusercontent.com/382048/204886013-65917131-91b9-4b7d-a9b5-a8ff38bde8ca.gif)
