### PR TITLE
Restrict tooltip to size of Bitcoin balance

### DIFF
--- a/lib/app_bar_with_balance.dart
+++ b/lib/app_bar_with_balance.dart
@@ -34,7 +34,7 @@ class AppBarWithBalance extends StatelessWidget {
           ),
           Padding(
             padding: const EdgeInsets.only(left: 20.0, right: 20.0, top: 20.0, bottom: 10.0),
-            child: Balance(balanceSelector: balanceSelector),
+            child: Center(child: Balance(balanceSelector: balanceSelector)),
           )
         ]),
         const Padding(

--- a/lib/balance.dart
+++ b/lib/balance.dart
@@ -83,10 +83,10 @@ class BalanceRow extends StatelessWidget {
     final balanceFontSize = smaller ? 26.0 : 32.0;
     final iconSize = smaller ? 24.0 : 28.0;
 
-    return Center(
-        child: Row(
+    return Row(
       mainAxisAlignment: MainAxisAlignment.center,
       textBaseline: TextBaseline.alphabetic,
+      mainAxisSize: MainAxisSize.min,
       children: [
         Icon(icon, size: 32),
         AmountItem(
@@ -97,6 +97,6 @@ class BalanceRow extends StatelessWidget {
           fontSize: balanceFontSize,
         )
       ],
-    ));
+    );
   }
 }


### PR DESCRIPTION
The tooltip was created around the whole `Row`, which could cause trouble with opening the menu drawer in the `Bitcoin` wallet screen. The menu drawer was not properly clickable because the tooltip partly overlayed it.

Fixed by moving restricting the size of the `Row` to min (so it does not auto-expand) and moving the `Center` to the outside (it should not have been part of the `Balance` in the first place, the caller should decide how to layout the balance).