### PR TITLE
fix: Center the dashboard tiles

### DIFF
--- a/lib/wallet/wallet_dashboard.dart
+++ b/lib/wallet/wallet_dashboard.dart
@@ -124,25 +124,22 @@ class ServiceNavigation extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return SizedBox(
-      height: 100.0,
-      child: ListView(
-        scrollDirection: Axis.horizontal,
-        children: [
-          GestureDetector(
-            onTap: () => {GoRouter.of(context).go(Service.trade.route)},
-            child: const ServiceCard(Service.trade),
-          ),
-          GestureDetector(
-            onTap: () => {GoRouter.of(context).go(Service.dca.route)},
-            child: const ServiceCard(Service.dca),
-          ),
-          GestureDetector(
-            onTap: () => {GoRouter.of(context).go(Service.savings.route)},
-            child: const ServiceCard(Service.savings),
-          ),
-        ],
-      ),
+    return Row(
+      mainAxisAlignment: MainAxisAlignment.center,
+      children: [
+        GestureDetector(
+          onTap: () => {GoRouter.of(context).go(Service.trade.route)},
+          child: const ServiceCard(Service.trade),
+        ),
+        GestureDetector(
+          onTap: () => {GoRouter.of(context).go(Service.dca.route)},
+          child: const ServiceCard(Service.dca),
+        ),
+        GestureDetector(
+          onTap: () => {GoRouter.of(context).go(Service.savings.route)},
+          child: const ServiceCard(Service.savings),
+        ),
+      ],
     );
   }
 }


### PR DESCRIPTION
It's not a ListView anymore, but given the amount of the tiles there's no way to
overflow it on any mobile screen (tested on iPhone SE3)