### PR TITLE
Fix collaborative channel close amounts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1298,7 +1298,7 @@ dependencies = [
 [[package]]
 name = "lightning"
 version = "0.0.112"
-source = "git+https://github.com/itchysats/rust-lightning?rev=82ce43637d0180b4d98d4aab1e272bfac81d1b57#82ce43637d0180b4d98d4aab1e272bfac81d1b57"
+source = "git+https://github.com/itchysats/rust-lightning?rev=10b69c99ea13c6c2c55c74a7497764a6303b9d34#10b69c99ea13c6c2c55c74a7497764a6303b9d34"
 dependencies = [
  "bitcoin",
 ]
@@ -1306,7 +1306,7 @@ dependencies = [
 [[package]]
 name = "lightning-background-processor"
 version = "0.0.112"
-source = "git+https://github.com/itchysats/rust-lightning?rev=82ce43637d0180b4d98d4aab1e272bfac81d1b57#82ce43637d0180b4d98d4aab1e272bfac81d1b57"
+source = "git+https://github.com/itchysats/rust-lightning?rev=10b69c99ea13c6c2c55c74a7497764a6303b9d34#10b69c99ea13c6c2c55c74a7497764a6303b9d34"
 dependencies = [
  "bitcoin",
  "lightning",
@@ -1316,7 +1316,7 @@ dependencies = [
 [[package]]
 name = "lightning-block-sync"
 version = "0.0.112"
-source = "git+https://github.com/itchysats/rust-lightning?rev=82ce43637d0180b4d98d4aab1e272bfac81d1b57#82ce43637d0180b4d98d4aab1e272bfac81d1b57"
+source = "git+https://github.com/itchysats/rust-lightning?rev=10b69c99ea13c6c2c55c74a7497764a6303b9d34#10b69c99ea13c6c2c55c74a7497764a6303b9d34"
 dependencies = [
  "bitcoin",
  "chunked_transfer",
@@ -1329,7 +1329,7 @@ dependencies = [
 [[package]]
 name = "lightning-invoice"
 version = "0.20.0"
-source = "git+https://github.com/itchysats/rust-lightning?rev=82ce43637d0180b4d98d4aab1e272bfac81d1b57#82ce43637d0180b4d98d4aab1e272bfac81d1b57"
+source = "git+https://github.com/itchysats/rust-lightning?rev=10b69c99ea13c6c2c55c74a7497764a6303b9d34#10b69c99ea13c6c2c55c74a7497764a6303b9d34"
 dependencies = [
  "bech32 0.9.1",
  "bitcoin",
@@ -1342,7 +1342,7 @@ dependencies = [
 [[package]]
 name = "lightning-net-tokio"
 version = "0.0.112"
-source = "git+https://github.com/itchysats/rust-lightning?rev=82ce43637d0180b4d98d4aab1e272bfac81d1b57#82ce43637d0180b4d98d4aab1e272bfac81d1b57"
+source = "git+https://github.com/itchysats/rust-lightning?rev=10b69c99ea13c6c2c55c74a7497764a6303b9d34#10b69c99ea13c6c2c55c74a7497764a6303b9d34"
 dependencies = [
  "bitcoin",
  "lightning",
@@ -1352,7 +1352,7 @@ dependencies = [
 [[package]]
 name = "lightning-persister"
 version = "0.0.112"
-source = "git+https://github.com/itchysats/rust-lightning?rev=82ce43637d0180b4d98d4aab1e272bfac81d1b57#82ce43637d0180b4d98d4aab1e272bfac81d1b57"
+source = "git+https://github.com/itchysats/rust-lightning?rev=10b69c99ea13c6c2c55c74a7497764a6303b9d34#10b69c99ea13c6c2c55c74a7497764a6303b9d34"
 dependencies = [
  "bitcoin",
  "libc",
@@ -1363,7 +1363,7 @@ dependencies = [
 [[package]]
 name = "lightning-rapid-gossip-sync"
 version = "0.0.112"
-source = "git+https://github.com/itchysats/rust-lightning?rev=82ce43637d0180b4d98d4aab1e272bfac81d1b57#82ce43637d0180b4d98d4aab1e272bfac81d1b57"
+source = "git+https://github.com/itchysats/rust-lightning?rev=10b69c99ea13c6c2c55c74a7497764a6303b9d34#10b69c99ea13c6c2c55c74a7497764a6303b9d34"
 dependencies = [
  "bitcoin",
  "lightning",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,10 +4,10 @@ resolver = "2"
 
 [patch.crates-io]
 bdk-ldk = { git = "https://github.com/itchysats/bdk-ldk", rev = "07dc94dcaa466d9bece8636a538757c97fe3663c" } # unreleased
-lightning = { git = "https://github.com/itchysats/rust-lightning", rev = "82ce43637d0180b4d98d4aab1e272bfac81d1b57" }
-lightning-background-processor = { git = "https://github.com/itchysats/rust-lightning", rev = "82ce43637d0180b4d98d4aab1e272bfac81d1b57" }
-lightning-block-sync = { git = "https://github.com/itchysats/rust-lightning", rev = "82ce43637d0180b4d98d4aab1e272bfac81d1b57" }
-lightning-invoice = { git = "https://github.com/itchysats/rust-lightning", rev = "82ce43637d0180b4d98d4aab1e272bfac81d1b57" }
-lightning-net-tokio = { git = "https://github.com/itchysats/rust-lightning", rev = "82ce43637d0180b4d98d4aab1e272bfac81d1b57" }
-lightning-persister = { git = "https://github.com/itchysats/rust-lightning", rev = "82ce43637d0180b4d98d4aab1e272bfac81d1b57" }
-lightning-rapid-gossip-sync = { git = "https://github.com/itchysats/rust-lightning", rev = "82ce43637d0180b4d98d4aab1e272bfac81d1b57" }
+lightning = { git = "https://github.com/itchysats/rust-lightning", rev = "10b69c99ea13c6c2c55c74a7497764a6303b9d34" }
+lightning-background-processor = { git = "https://github.com/itchysats/rust-lightning", rev = "10b69c99ea13c6c2c55c74a7497764a6303b9d34" }
+lightning-block-sync = { git = "https://github.com/itchysats/rust-lightning", rev = "10b69c99ea13c6c2c55c74a7497764a6303b9d34" }
+lightning-invoice = { git = "https://github.com/itchysats/rust-lightning", rev = "10b69c99ea13c6c2c55c74a7497764a6303b9d34" }
+lightning-net-tokio = { git = "https://github.com/itchysats/rust-lightning", rev = "10b69c99ea13c6c2c55c74a7497764a6303b9d34" }
+lightning-persister = { git = "https://github.com/itchysats/rust-lightning", rev = "10b69c99ea13c6c2c55c74a7497764a6303b9d34" }
+lightning-rapid-gossip-sync = { git = "https://github.com/itchysats/rust-lightning", rev = "10b69c99ea13c6c2c55c74a7497764a6303b9d34" }


### PR DESCRIPTION
Fixes https://github.com/itchysats/10101/issues/475.

They were wrong because of a bug in our fork of `rust-lightning`: the channel amounts were not being updated after the custom output was removed.

We were already constructing the correct commitment transaction and because we only ever tested using force-close it looked like everything was working as intended!