### PR TITLE
Ignore reorgs for the greater good

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -219,7 +219,7 @@ dependencies = [
 [[package]]
 name = "bdk-ldk"
 version = "0.1.0"
-source = "git+https://github.com/itchysats/bdk-ldk?rev=07dc94dcaa466d9bece8636a538757c97fe3663c#07dc94dcaa466d9bece8636a538757c97fe3663c"
+source = "git+https://github.com/itchysats/bdk-ldk?rev=c66ad845391a67a80554962bab55a237775150df#c66ad845391a67a80554962bab55a237775150df"
 dependencies = [
  "anyhow",
  "bdk",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["rust", "maker"]
 resolver = "2"
 
 [patch.crates-io]
-bdk-ldk = { git = "https://github.com/itchysats/bdk-ldk", rev = "07dc94dcaa466d9bece8636a538757c97fe3663c" } # unreleased
+bdk-ldk = { git = "https://github.com/itchysats/bdk-ldk", rev = "c66ad845391a67a80554962bab55a237775150df" } # unreleased
 lightning = { git = "https://github.com/itchysats/rust-lightning", rev = "10b69c99ea13c6c2c55c74a7497764a6303b9d34" }
 lightning-background-processor = { git = "https://github.com/itchysats/rust-lightning", rev = "10b69c99ea13c6c2c55c74a7497764a6303b9d34" }
 lightning-block-sync = { git = "https://github.com/itchysats/rust-lightning", rev = "10b69c99ea13c6c2c55c74a7497764a6303b9d34" }


### PR DESCRIPTION
The latest version of `bdk-ldk` removes some possibly buggy code which dealt with reorgs. Reorgs aren't very important in the context of a test application and we think that the possibly buggy code was causing unwarranted channel force-closes.