### PR TITLE
fix: Allow manual input of lightning invoice

### DIFF
--- a/lib/wallet/qr_scan.dart
+++ b/lib/wallet/qr_scan.dart
@@ -12,6 +12,12 @@ class QrScanChangeNotifier extends ChangeNotifier {
     this.code = code;
     super.notifyListeners();
   }
+
+  String consume() {
+    final consumed = code;
+    code = "";
+    return consumed;
+  }
 }
 
 class QrScan extends StatefulWidget {

--- a/lib/wallet/send.dart
+++ b/lib/wallet/send.dart
@@ -36,13 +36,15 @@ class _SendState extends State<Send> {
     formatter.maximumFractionDigits = 0;
     final qrScanChangeNotifier = context.watch<QrScanChangeNotifier>();
 
-    encodedInvoice = qrScanChangeNotifier.code;
-    tryDecodeInvoice();
+    if (qrScanChangeNotifier.code.isNotEmpty) {
+      encodedInvoice = qrScanChangeNotifier.consume();
+      tryDecodeInvoice();
+    }
 
     final widgets = [
       const Text("Encoded Invoice", style: TextStyle(color: Colors.grey, fontSize: 18)),
       Focus(
-        onFocusChange: (hasFocus) async {
+        onFocusChange: (hasFocus) {
           if (encodedInvoice.isEmpty || hasFocus) {
             invoice = null;
           } else {
@@ -50,7 +52,7 @@ class _SendState extends State<Send> {
           }
         },
         child: TextFormField(
-          initialValue: qrScanChangeNotifier.code,
+          initialValue: encodedInvoice,
           keyboardType: TextInputType.text,
           onChanged: (text) {
             setState(() {


### PR DESCRIPTION
Fixes a minor regression that invoices can't be entered manually anymore. Also when looking into this bug, I figured it's probably nicer to have the QR code scanning icon next to the field. That way we could make it a reusable widget.