### PR TITLE
feat: Wait for channel to become available

### DIFF
--- a/lib/cfd_trading/cfd_offer.dart
+++ b/lib/cfd_trading/cfd_offer.dart
@@ -14,6 +14,7 @@ import 'package:ten_ten_one/models/balance_model.dart';
 import 'package:ten_ten_one/utilities/dropdown.dart';
 import 'package:ten_ten_one/utilities/tto_table.dart';
 import 'package:ten_ten_one/ffi.io.dart' if (dart.library.html) 'ffi.web.dart';
+import 'package:ten_ten_one/wallet/channel_change_notifier.dart';
 
 class CfdOffer extends StatefulWidget {
   static const leverages = [1, 2, 3, 4, 5, 10];
@@ -66,11 +67,12 @@ class _CfdOfferState extends State<CfdOffer> {
         .format(DateTime.fromMillisecondsSinceEpoch((order.calculateExpiry() * 1000)));
     final margin = Amount.fromBtc(order.marginTaker()).display(currency: Currency.sat).value;
 
-    final balance = context.read<LightningBalance>().amount.asSats;
+    final balance = context.watch<LightningBalance>().amount.asSats;
+    final channel = context.watch<ChannelChangeNotifier>();
     final int takerAmount = Amount.fromBtc(order.marginTaker()).asSats;
 
     Message? channelError;
-    if (balance == 0) {
+    if (!channel.isAvailable()) {
       channelError = Message(
           title: 'No channel with 10101 maker',
           details: 'You need an open channel with the 10101 maker before you can open a CFD.',

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -69,7 +69,7 @@ void main() {
     ChangeNotifierProvider(create: (context) => QrScanChangeNotifier()),
     ChangeNotifierProvider(create: (context) => WalletChangeNotifier()),
     ChangeNotifierProvider(create: (context) => cfdOffersChangeNotifier),
-    ChangeNotifierProvider(create: (context) => ChannelChangeNotifier()),
+    ChangeNotifierProvider(create: (context) => ChannelChangeNotifier().init()),
   ], child: const TenTenOneApp()));
 }
 

--- a/lib/wallet/channel_change_notifier.dart
+++ b/lib/wallet/channel_change_notifier.dart
@@ -1,16 +1,30 @@
 import 'dart:async';
 
 import 'package:flutter/material.dart';
+import 'package:ten_ten_one/bridge_generated/bridge_definitions.dart';
 import 'package:ten_ten_one/ffi.io.dart' if (dart.library.html) 'ffi.web.dart';
 
 class ChannelChangeNotifier extends ChangeNotifier {
-  bool _init = false;
-  bool isInitialising() => _init;
+  ChannelState state = ChannelState.Unavailable;
+
+  bool isInitialising() => state == ChannelState.Establishing;
+
+  bool isAvailable() => state == ChannelState.Available;
 
   Future<void> open(int amount) async {
-    super.notifyListeners();
-    _init = true;
     await api.openChannel(takerAmount: amount);
-    Timer(const Duration(seconds: 60), () => _init = false);
+    state = ChannelState.Establishing;
+    super.notifyListeners();
+  }
+
+  ChannelChangeNotifier init() {
+    Timer.periodic(const Duration(seconds: 5), (timer) async {
+      final channelState = await api.getChannelState();
+      if (state != channelState) {
+        state = channelState;
+        super.notifyListeners();
+      }
+    });
+    return this;
   }
 }

--- a/lib/wallet/drain_faucet.dart
+++ b/lib/wallet/drain_faucet.dart
@@ -4,6 +4,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_rust_bridge/flutter_rust_bridge.dart';
 import 'package:go_router/go_router.dart';
 import 'package:ten_ten_one/cfd_trading/validation_error.dart';
+import 'package:ten_ten_one/utilities/submit_button.dart';
 import 'package:url_launcher/url_launcher.dart';
 
 import 'package:ten_ten_one/ffi.io.dart' if (dart.library.html) 'ffi.web.dart';
@@ -86,7 +87,7 @@ class _DrainFaucetState extends State<DrainFaucet> {
                       const Spacer(),
                       Container(
                         alignment: Alignment.bottomRight,
-                        child: ElevatedButton(
+                        child: SubmitButton(
                             onPressed: () async {
                               try {
                                 final txid = await api.callFaucet(address: address);
@@ -94,14 +95,18 @@ class _DrainFaucetState extends State<DrainFaucet> {
                                 ScaffoldMessenger.of(context).showSnackBar(const SnackBar(
                                   content: Text("Success. Your funds will arrive shortly."),
                                 ));
+                                GoRouter.of(context).go('/');
                               } on FfiException catch (error) {
                                 FLog.error(
                                     text: "Failed to call faucet: Error: " + error.message,
                                     exception: error);
+                                ScaffoldMessenger.of(context).showSnackBar(SnackBar(
+                                  backgroundColor: Colors.red,
+                                  content: Text("Failed to call faucet: Error: " + error.message),
+                                ));
                               }
-                              GoRouter.of(context).go('/');
                             },
-                            child: const Text('Fund me')),
+                            label: 'Fund me'),
                       )
                     ],
                   ),

--- a/lib/wallet/wallet_dashboard.dart
+++ b/lib/wallet/wallet_dashboard.dart
@@ -40,7 +40,6 @@ class _WalletDashboardState extends State<WalletDashboard> {
   Widget build(BuildContext context) {
     final seedBackupModel = context.watch<SeedBackupModel>();
     final bitcoinBalance = context.watch<BitcoinBalance>();
-    final lightningBalance = context.watch<LightningBalance>();
     final paymentHistory = context.watch<PaymentHistory>();
     final channel = context.watch<ChannelChangeNotifier>();
 
@@ -65,7 +64,7 @@ class _WalletDashboardState extends State<WalletDashboard> {
           icon: const Icon(Icons.link))));
     }
 
-    if (bitcoinBalance.total().asSats != 0 && lightningBalance.amount.asSats == 0) {
+    if (bitcoinBalance.total().asSats > 0 && !(channel.isAvailable() || channel.isInitialising())) {
       widgets.add(ActionCard(CardDetails(
         route: OpenChannel.route,
         title: "Open Channel",

--- a/lib/wallet/wallet_lightning.dart
+++ b/lib/wallet/wallet_lightning.dart
@@ -6,7 +6,7 @@ import 'package:provider/provider.dart';
 import 'package:ten_ten_one/cfd_trading/cfd_trading_change_notifier.dart';
 import 'package:ten_ten_one/cfd_trading/validation_error.dart';
 import 'package:ten_ten_one/main.dart';
-import 'package:ten_ten_one/models/balance_model.dart';
+import 'package:ten_ten_one/wallet/channel_change_notifier.dart';
 import 'package:ten_ten_one/wallet/close_channel.dart';
 import 'package:ten_ten_one/wallet/payment_history_list_item.dart';
 import 'package:ten_ten_one/wallet/receive.dart';
@@ -23,7 +23,7 @@ class WalletLightning extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final history = context.watch<PaymentHistory>();
-    final balance = context.watch<LightningBalance>();
+    final channel = context.watch<ChannelChangeNotifier>();
 
     List<Widget> widgets = [];
 
@@ -70,11 +70,7 @@ class WalletLightning extends StatelessWidget {
       )
     ];
 
-    // close channel should only be possible if a channel is opened. the lightning balance is not
-    // directly indicating that a channel is open, but on the other hand no lightning balance can
-    // exist without a channel. Hence this is good enough for now, eventually the channel should be
-    // reflected in our data model.
-    if (balance.amount.asSats > 0) {
+    if (channel.isAvailable()) {
       dials.insert(
           0,
           SpeedDialChild(

--- a/rust/src/api.rs
+++ b/rust/src/api.rs
@@ -78,6 +78,25 @@ pub fn init_wallet(path: String) -> Result<()> {
     wallet::init_wallet(Path::new(path.as_str()))
 }
 
+pub enum ChannelState {
+    Unavailable,
+    Establishing,
+    Available,
+}
+
+pub fn get_channel_state() -> ChannelState {
+    match wallet::get_first_channel_details() {
+        Some(channel_details) => {
+            if channel_details.is_usable {
+                ChannelState::Available
+            } else {
+                ChannelState::Establishing
+            }
+        }
+        None => ChannelState::Unavailable,
+    }
+}
+
 pub struct LightningInvoice {
     pub description: String,
     pub amount_sats: f64,

--- a/rust/src/connection.rs
+++ b/rust/src/connection.rs
@@ -7,9 +7,7 @@ use anyhow::Result;
 pub async fn keep_alive() -> Result<()> {
     let mut connected = false;
     loop {
-        let is_connection_lost_maybe = !is_first_channel_usable()?;
-
-        if !connected || is_connection_lost_maybe {
+        if !connected || !is_first_channel_usable() {
             connected = connect().await?;
         }
 

--- a/rust/src/wallet.rs
+++ b/rust/src/wallet.rs
@@ -521,13 +521,11 @@ pub async fn open_channel(peer_info: PeerInfo, taker_amount: u64) -> Result<()> 
 /// If the first channel is not usable, it might be because we've lost
 /// the connection with the 10101 maker, according to the
 /// `rust-lightning` logs.
-pub fn is_first_channel_usable() -> Result<bool> {
-    let is_usable = match get_first_channel_details() {
+pub fn is_first_channel_usable() -> bool {
+    match get_first_channel_details() {
         Some(channel_details) => channel_details.is_usable,
         None => false,
-    };
-
-    Ok(is_usable)
+    }
 }
 
 pub fn get_first_channel_details() -> Option<ChannelDetails> {

--- a/rust/src/wallet.rs
+++ b/rust/src/wallet.rs
@@ -544,7 +544,7 @@ pub async fn connect() -> Result<()> {
         lightning.peer_manager.clone()
     };
     let peer_info = maker_peer_info();
-    tracing::debug!("Connection with {peer_info}");
+    tracing::debug!("Connecting with {peer_info}");
     lightning::connect_peer_if_necessary(&peer_info, peer_manager).await?;
 
     Ok(())

--- a/rust/src/wallet.rs
+++ b/rust/src/wallet.rs
@@ -14,6 +14,7 @@ use crate::lightning::NodeInfo;
 use crate::lightning::PeerInfo;
 use crate::seed::Bip39Seed;
 use ::lightning::chain::chaininterface::ConfirmationTarget;
+use ::lightning::ln::channelmanager::ChannelDetails;
 use anyhow::anyhow;
 use anyhow::bail;
 use anyhow::Context;
@@ -521,18 +522,21 @@ pub async fn open_channel(peer_info: PeerInfo, taker_amount: u64) -> Result<()> 
 /// the connection with the 10101 maker, according to the
 /// `rust-lightning` logs.
 pub fn is_first_channel_usable() -> Result<bool> {
-    let channel_manager = {
-        let lightning = &get_wallet()?.lightning;
-
-        lightning.channel_manager.clone()
-    };
-
-    let is_usable = match channel_manager.list_channels().first() {
+    let is_usable = match get_first_channel_details() {
         Some(channel_details) => channel_details.is_usable,
-        None => return Ok(false),
+        None => false,
     };
 
     Ok(is_usable)
+}
+
+pub fn get_first_channel_details() -> Option<ChannelDetails> {
+    let channel_manager = match &get_wallet() {
+        Ok(wallet) => Some(wallet.lightning.channel_manager.clone()),
+        Err(_) => None,
+    }?;
+
+    channel_manager.list_channels().first().cloned()
 }
 
 pub async fn connect() -> Result<()> {


### PR DESCRIPTION
Before that PR we where only depending on a timeout and a lightning balance. However, this led to several error messages as a lightning balance does not mean the channel is usable.

The PR introduces a sync of the channel state every 5 seconds representing the following 3 states:

1. Unavailable: No channel exists
2. Establishing: Channel exists but is not usable yet
3. Available: Channel exists and is usable


ebe4fb219a61b1802e673723916a77b8bad79ad4 fixes a regression after merging https://github.com/itchysats/10101/pull/483: we can not assume there is always a channel available. The taker was trying to reconnect constantly if no channel was available or if it was in creation. It's hard to distinguish between a good and a bad usable channel (as it might be in creation) - I am using the `short_channel_id` now to distinguish if the channel is actually in a bad state or everything is fine.