### PR TITLE
feat: Add Settings placeholder

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -236,6 +236,22 @@ class _TenTenOneState extends State<TenTenOneApp> {
                   "When is the best time to buy Bitcoin? Now! DCA is a constant investment strategy to buy smaller amounts of Bitcoin over a period of time, no matter what price. DCA is coming soon!");
         },
       ),
+      GoRoute(
+        path: Service.savings.route,
+        builder: (BuildContext context, GoRouterState state) {
+          return const ServicePlaceholder(
+              service: Service.savings, description: "We bring stacking to Bitcoin!");
+        },
+      ),
+      // TODO: Change Settings from Service to normal page when implemented
+      GoRoute(
+        path: Service.settings.route,
+        builder: (BuildContext context, GoRouterState state) {
+          return const ServicePlaceholder(
+              service: Service.settings,
+              description: "Here is the spot to tweak the settings of 10101 app. Stay tuned!");
+        },
+      ),
     ],
   );
 

--- a/lib/menu.dart
+++ b/lib/menu.dart
@@ -83,11 +83,14 @@ class Menu extends StatelessWidget {
             ),
           ]),
       ListTile(
-        title: const Text("Settings"),
-        leading: const Icon(Icons.settings),
-        // TODO: Add `selected` when added route (PR is open)
+        title: Text(Service.settings.label),
+        leading: Icon(Service.settings.icon),
+        selected: GoRouter.of(context).location == Service.settings.route,
         selectedTileColor: selectedTile,
-        onTap: () {},
+        onTap: () {
+          Navigator.pop(context);
+          GoRouter.of(context).go(Service.settings.route);
+        },
       ),
     ];
 

--- a/lib/models/service_model.dart
+++ b/lib/models/service_model.dart
@@ -21,28 +21,32 @@ extension ServiceGroupExtension on ServiceGroup {
   IconData get icon => icons[this]!;
 }
 
-enum Service { trade, dca, savings }
+enum Service { trade, dca, savings, settings }
 
 extension ServiceExtension on Service {
   static const labels = {
     Service.trade: "Trading",
     Service.dca: "Dollar Cost Average",
-    Service.savings: "Saving"
+    Service.savings: "Saving",
+    Service.settings: "Settings",
   };
   static const shortLabels = {
     Service.trade: "Trade",
     Service.dca: "DCA",
-    Service.savings: "Savings"
+    Service.savings: "Savings",
+    Service.settings: "Settings"
   };
   static const icons = {
     Service.trade: Icons.insights,
     Service.dca: FontAwesomeIcons.moneyBill1,
-    Service.savings: Icons.savings
+    Service.savings: Icons.savings,
+    Service.settings: Icons.settings,
   };
   static const routes = {
     Service.trade: "/trading",
     Service.dca: "/dca",
-    Service.savings: "/savings"
+    Service.savings: "/savings",
+    Service.settings: "/settings",
   };
 
   String get label => labels[this]!;


### PR DESCRIPTION
Certainly better behaviour than not allowing a click in that part of the menu.

A bit of a kludge, abusing the same Service placeholder for Settings screen.