### PR TITLE
Update on-chain balance immediately after channel closure

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -219,7 +219,7 @@ dependencies = [
 [[package]]
 name = "bdk-ldk"
 version = "0.1.0"
-source = "git+https://github.com/itchysats/bdk-ldk?rev=c66ad845391a67a80554962bab55a237775150df#c66ad845391a67a80554962bab55a237775150df"
+source = "git+https://github.com/itchysats/bdk-ldk?rev=a096f232dec8c5a50f77b54a67da46d7c9b1311a#a096f232dec8c5a50f77b54a67da46d7c9b1311a"
 dependencies = [
  "anyhow",
  "bdk",

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -319,8 +319,8 @@ Future<void> callGetBalances() async {
   try {
     final balance = await api.getBalance();
     bitcoinBalance.update(Amount(balance.onChain.confirmed), Amount(balance.onChain.trustedPending),
-        Amount(balance.onChain.untrustedPending));
-    lightningBalance.update(Amount(balance.offChain));
+        Amount(balance.onChain.untrustedPending), Amount(balance.offChain.pendingClose));
+    lightningBalance.update(Amount(balance.offChain.available));
     FLog.trace(text: 'Successfully retrieved wallet balances');
   } catch (error) {
     FLog.error(text: "Failed to get balances:" + error.toString());

--- a/lib/models/balance_model.dart
+++ b/lib/models/balance_model.dart
@@ -14,19 +14,22 @@ class BitcoinBalance extends ChangeNotifier {
   Amount confirmed = Amount.zero;
   Amount pendingInternal = Amount.zero;
   Amount pendingExternal = Amount.zero;
+  Amount pendingChannelClose = Amount.zero;
 
   Amount pending() {
-    return Amount(pendingExternal.asSats + pendingInternal.asSats);
+    return Amount(pendingExternal.asSats + pendingInternal.asSats + pendingChannelClose.asSats);
   }
 
   Amount total() {
     return Amount(confirmed.asSats + pending().asSats);
   }
 
-  void update(Amount confirmed, Amount pendingInternal, Amount pendingExternal) {
+  void update(Amount confirmed, Amount pendingInternal, Amount pendingExternal,
+      Amount pendingChannelClose) {
     this.confirmed = confirmed;
     this.pendingInternal = pendingInternal;
     this.pendingExternal = pendingExternal;
+    this.pendingChannelClose = pendingChannelClose;
 
     super.notifyListeners();
   }

--- a/lib/wallet/close_channel.dart
+++ b/lib/wallet/close_channel.dart
@@ -55,6 +55,9 @@ class _CloseChannelState extends State<CloseChannel> {
                               "Closing the channel will send ${closeAmount.value} sats to your 10101 on-chain wallet.\n\n"),
                       const TextSpan(
                           text:
+                              "It will take at least 2 blocks after the publication of the channel close transaction for your coins to be confirmed by your on-chain wallet.\n\n"),
+                      const TextSpan(
+                          text:
                               "Once the channel is closed, you will have to open a new one if you want to continue using your wallet for Lightning payments and trading.")
                     ])),
               ),
@@ -90,7 +93,7 @@ class _CloseChannelState extends State<CloseChannel> {
   }
 
   Future<void> closeChannel() async {
-    FLog.info(text: "Closing channel with outbound liquidity of " + closeAmount.toString());
+    FLog.info(text: "Closing channel with outbound liquidity of " + closeAmount.value.toString());
 
     try {
       await api.closeChannel();


### PR DESCRIPTION
Fixes #461.

The coins are correctly moved to a pending state, like we do with any other on-chain transaction.

The user is also informed about what to expect when closing the channel.

It's important to note that if the user runs into a force-closure for some other reason, the coins will also go into a pending state and be reflected in the overall on-chain balance, but it will take _hundreds_ of confirmations for the coins to be confirmed.

![image](https://user-images.githubusercontent.com/9418575/205271194-a34a118e-2ac5-45d8-a6a7-b511e15f5528.png)
