### PR TITLE
chore: Set log level to debug

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -58,7 +58,7 @@ void main() {
   };
 
   final config = FLog.getDefaultConfigurations();
-  config.activeLogLevel = foundation.kReleaseMode ? LogLevel.INFO : LogLevel.DEBUG;
+  config.activeLogLevel = LogLevel.DEBUG;
 
   FLog.applyConfigurations(config);
 


### PR DESCRIPTION
Otherwise the logs attached in the feedback email don't help a lot.

all rust logs are still logged on debug - this should be fixed with https://github.com/itchysats/10101/issues/510