### PR TITLE
Do not auto-open the keyboard

### DIFF
--- a/lib/cfd_trading/cfd_offer.dart
+++ b/lib/cfd_trading/cfd_offer.dart
@@ -176,7 +176,6 @@ class _CfdOfferState extends State<CfdOffer> {
                       keyboardType: TextInputType.number,
                       inputFormatters: [FilteringTextInputFormatter.digitsOnly],
                       style: const TextStyle(fontSize: 18.0),
-                      autofocus: true,
                       initialValue: order.quantity.toString(),
                       onChanged: (value) {
                         setState(() {


### PR DESCRIPTION
#fixes https://github.com/itchysats/10101/issues/514

If we auto-open the keyboard the user is unable to navigate to other views (e.g. My CFDs) of the is screen.

Note: I don't think there is a better way to fix this without a bigger redesign of that screen - we could try to push the bottom menu up with the keyboard, but I think this will mess with the screen overall, because we don't have enough space to do that.