### PR TITLE
Log `txid` to be ignored that was saved in db

### DIFF
--- a/rust/src/db.rs
+++ b/rust/src/db.rs
@@ -119,7 +119,7 @@ pub async fn insert_ignore_txid(txid: Txid, maker_amount: i64) -> Result<()> {
         bail!("Failed to insert txid to be ignored");
     }
 
-    tracing::info!("Successfully stored txid to be ignored");
+    tracing::info!("Successfully stored txid {txid} to be ignored");
 
     Ok(())
 }


### PR DESCRIPTION
would have been helpful when debugging