### PR TITLE
fix: Scoped wallet lock only for clone

### DIFF
--- a/rust/src/wallet.rs
+++ b/rust/src/wallet.rs
@@ -454,7 +454,8 @@ pub fn get_balance() -> Result<Balance> {
 
 pub fn sync() -> Result<()> {
     tracing::trace!("Wallet sync called");
-    get_wallet()?.sync()
+    let wallet = { (*get_wallet()?).clone() };
+    wallet.sync()
 }
 
 pub fn network() -> Result<bitcoin::Network> {


### PR DESCRIPTION
That will hopefully free up resources on the maker.