### PR TITLE
feat: Reflect disconnected maker

### DIFF
--- a/lib/cfd_trading/cfd_offer.dart
+++ b/lib/cfd_trading/cfd_offer.dart
@@ -73,7 +73,7 @@ class _CfdOfferState extends State<CfdOffer> {
     final channel = context.watch<ChannelChangeNotifier>();
     final int takerAmount = Amount.fromBtc(order.marginTaker()).asSats;
 
-    Message? message = channel.validate();
+    Message? message = channel.status();
 
     if (noOffer && message == null) {
       message = Message(

--- a/lib/wallet/action_card.dart
+++ b/lib/wallet/action_card.dart
@@ -3,14 +3,14 @@ import 'package:go_router/go_router.dart';
 
 class CardDetails {
   final String title;
-  final String route;
+  String? route;
   final String subtitle;
   final Widget icon;
   bool disabled;
 
   CardDetails(
       {required this.title,
-      required this.route,
+      this.route,
       required this.subtitle,
       required this.icon,
       this.disabled = false});
@@ -24,7 +24,9 @@ class ActionCard extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return GestureDetector(
-        onTap: details.disabled ? null : () => {GoRouter.of(context).go(details.route)},
+        onTap: details.disabled || details.route == null
+            ? null
+            : () => {GoRouter.of(context).go(details.route!)},
         child: Card(
           color: details.disabled ? Colors.grey.shade300 : Colors.white,
           elevation: 4,

--- a/lib/wallet/channel_change_notifier.dart
+++ b/lib/wallet/channel_change_notifier.dart
@@ -2,14 +2,86 @@ import 'dart:async';
 
 import 'package:flutter/material.dart';
 import 'package:ten_ten_one/bridge_generated/bridge_definitions.dart';
+import 'package:ten_ten_one/cfd_trading/validation_error.dart';
 import 'package:ten_ten_one/ffi.io.dart' if (dart.library.html) 'ffi.web.dart';
+import 'package:ten_ten_one/wallet/action_card.dart';
+import 'package:ten_ten_one/wallet/open_channel.dart';
 
 class ChannelChangeNotifier extends ChangeNotifier {
-  ChannelState state = ChannelState.Unavailable;
+  ChannelState? state;
 
   bool isInitialising() => state == ChannelState.Establishing;
 
+  bool isDisconnected() => state == ChannelState.Disconnected;
+
   bool isAvailable() => state == ChannelState.Available;
+
+  bool isUnavailable() => state == ChannelState.Unavailable;
+
+  Message? validate() {
+    if (isUnavailable()) {
+      return Message(
+          title: 'No channel with 10101 maker',
+          details: 'You need an open channel with the 10101.',
+          type: AlertType.warning);
+    }
+
+    if (isInitialising()) {
+      return Message(
+          title: 'Channel not confirmed',
+          details: 'Please wait until your channel has 1 confirmation.',
+          type: AlertType.warning);
+    }
+
+    if (isDisconnected()) {
+      return Message(
+          title: 'Disconnected maker',
+          details: 'You are currently not connected to the maker.',
+          type: AlertType.warning);
+    }
+
+    return null;
+  }
+
+  CardDetails? buildCardDetails() {
+    switch (state) {
+      case ChannelState.Unavailable:
+        return CardDetails(
+            route: OpenChannel.route,
+            title: "Open Channel",
+            subtitle: "Open a channel to enable trading on Lightning",
+            icon: const Icon(Icons.launch));
+      case ChannelState.Establishing:
+        return CardDetails(
+            title: "Establishing Channel",
+            subtitle:
+                "Waiting for channel to get established. This may take a while, waiting for one confirmation.",
+            disabled: true,
+            icon: _buildSpinningWheel());
+      case ChannelState.Available:
+        return null;
+      case ChannelState.Disconnected:
+        return CardDetails(
+            title: "Disconnected Maker",
+            subtitle: "Trying to reconnect to the 10101 maker.",
+            disabled: true,
+            icon: _buildSpinningWheel());
+      default:
+        // no state has been synchronized yet. hence we will show no card until we have an actual channel state.
+        return null;
+    }
+  }
+
+  Widget _buildSpinningWheel() {
+    return Container(
+        width: 22,
+        height: 22,
+        padding: const EdgeInsets.all(2.0),
+        child: const CircularProgressIndicator(
+          color: Colors.grey,
+          strokeWidth: 3,
+        ));
+  }
 
   Future<void> open(int amount) async {
     await api.openChannel(takerAmount: amount);

--- a/lib/wallet/channel_change_notifier.dart
+++ b/lib/wallet/channel_change_notifier.dart
@@ -18,7 +18,7 @@ class ChannelChangeNotifier extends ChangeNotifier {
 
   bool isUnavailable() => state == ChannelState.Unavailable;
 
-  Message? validate() {
+  Message? status() {
     if (isUnavailable()) {
       return Message(
           title: 'No channel with 10101',

--- a/lib/wallet/channel_change_notifier.dart
+++ b/lib/wallet/channel_change_notifier.dart
@@ -21,22 +21,22 @@ class ChannelChangeNotifier extends ChangeNotifier {
   Message? validate() {
     if (isUnavailable()) {
       return Message(
-          title: 'No channel with 10101 maker',
-          details: 'You need an open channel with the 10101.',
+          title: 'No channel with 10101',
+          details: 'You need an open channel with 10101.',
           type: AlertType.warning);
     }
 
     if (isInitialising()) {
       return Message(
-          title: 'Channel not confirmed',
+          title: 'Channel not yet confirmed',
           details: 'Please wait until your channel has 1 confirmation.',
           type: AlertType.warning);
     }
 
     if (isDisconnected()) {
       return Message(
-          title: 'Disconnected maker',
-          details: 'You are currently not connected to the maker.',
+          title: 'Not connected to the 10101 node',
+          details: 'Automatically trying to reconnect to the 10101 Lightning node',
           type: AlertType.warning);
     }
 
@@ -62,8 +62,8 @@ class ChannelChangeNotifier extends ChangeNotifier {
         return null;
       case ChannelState.Disconnected:
         return CardDetails(
-            title: "Disconnected Maker",
-            subtitle: "Trying to reconnect to the 10101 maker.",
+            title: "Disconnected from 10101 ",
+            subtitle: "Automatically trying to reconnect to 10101 Lightning Node.",
             disabled: true,
             icon: _buildSpinningWheel());
       default:

--- a/lib/wallet/close_channel.dart
+++ b/lib/wallet/close_channel.dart
@@ -48,7 +48,7 @@ class _CloseChannelState extends State<CloseChannel> {
                         style: const TextStyle(color: Colors.black, fontSize: 18),
                         children: [
                       const TextSpan(
-                          text: "This will close your Lightning channel with the 10101 maker\n\n",
+                          text: "This will close your Lightning channel with 10101\n\n",
                           style: TextStyle(fontWeight: FontWeight.bold)),
                       TextSpan(
                           text:

--- a/lib/wallet/wallet_dashboard.dart
+++ b/lib/wallet/wallet_dashboard.dart
@@ -21,7 +21,6 @@ import 'package:ten_ten_one/wallet/seed.dart';
 import 'package:ten_ten_one/wallet/service_card.dart';
 
 import 'action_card.dart';
-import 'open_channel.dart';
 
 class WalletDashboard extends StatefulWidget {
   const WalletDashboard({Key? key}) : super(key: key);
@@ -64,24 +63,9 @@ class _WalletDashboardState extends State<WalletDashboard> {
           icon: const Icon(Icons.link))));
     }
 
-    if ((bitcoinBalance.total().asSats > 0 && !channel.isAvailable()) || channel.isInitialising()) {
-      widgets.add(ActionCard(CardDetails(
-        route: OpenChannel.route,
-        title: "Open Channel",
-        subtitle: "Open a channel to enable trading on Lightning",
-        disabled: channel.isInitialising(),
-        icon: channel.isInitialising()
-            ? Container(
-                width: 22,
-                height: 22,
-                padding: const EdgeInsets.all(2.0),
-                child: const CircularProgressIndicator(
-                  color: Colors.grey,
-                  strokeWidth: 3,
-                ),
-              )
-            : const Icon(Icons.launch),
-      )));
+    final channelCard = channel.buildCardDetails();
+    if (channelCard != null) {
+      widgets.add(ActionCard(channelCard));
     }
 
     final paymentHistoryList = ListView.builder(

--- a/lib/wallet/wallet_lightning.dart
+++ b/lib/wallet/wallet_lightning.dart
@@ -70,7 +70,7 @@ class WalletLightning extends StatelessWidget {
       )
     ];
 
-    Message? message = channel.validate();
+    Message? message = channel.status();
 
     if (channel.isAvailable()) {
       dials.insert(

--- a/lib/wallet/wallet_lightning.dart
+++ b/lib/wallet/wallet_lightning.dart
@@ -70,16 +70,7 @@ class WalletLightning extends StatelessWidget {
       )
     ];
 
-    var showActionButton = true;
-    Message? channelError;
-    if (!channel.isInitialising() && !channel.isAvailable()) {
-      channelError = Message(
-          title: 'No channel',
-          details:
-              'You do not have a lightning channel open at the moment. You can open one from the Dashboard screen.',
-          type: AlertType.warning);
-      showActionButton = false;
-    }
+    Message? message = channel.validate();
 
     if (channel.isAvailable()) {
       dials.insert(
@@ -92,16 +83,9 @@ class WalletLightning extends StatelessWidget {
           ));
     }
 
-    List<Widget> warnings = [];
-    if (channelError != null) {
-      warnings.addAll([
-        Expanded(child: Container()),
-        AlertMessage(message: channelError),
-        const SizedBox(height: 80)
-      ]);
+    if (message != null) {
+      widgets.insert(0, AlertMessage(message: message));
     }
-
-    widgets.addAll(warnings);
 
     return Scaffold(
       drawer: const Menu(),
@@ -114,7 +98,7 @@ class WalletLightning extends StatelessWidget {
         child: ListView(padding: const EdgeInsets.only(left: 25, right: 25), children: widgets),
       )),
       floatingActionButton: Visibility(
-        visible: showActionButton,
+        visible: message == null,
         child: SpeedDial(
           icon: Icons.import_export,
           iconTheme: const IconThemeData(size: 35),

--- a/rust/src/api.rs
+++ b/rust/src/api.rs
@@ -81,6 +81,7 @@ pub fn init_wallet(path: String) -> Result<()> {
 pub enum ChannelState {
     Unavailable,
     Establishing,
+    Disconnected,
     Available,
 }
 
@@ -89,7 +90,13 @@ pub fn get_channel_state() -> ChannelState {
         Some(channel_details) => {
             if channel_details.is_usable {
                 ChannelState::Available
+            } else if channel_details.is_channel_ready {
+                // an unusable, but ready channel indicates that the maker might be
+                // disconnected.
+                ChannelState::Disconnected
             } else {
+                // if the channel is not usable and not ready - we are currently establishing a
+                // channel with the maker.
                 ChannelState::Establishing
             }
         }


### PR DESCRIPTION
<img width="959" alt="Screenshot 2022-12-05 at 13 07 04" src="https://user-images.githubusercontent.com/382048/205633579-b3235481-405b-4988-bf6b-07fd1b165ae7.png">

- Uses `is_channel_ready` to distinguish between the establishing and disconnected state. According to the docs is_channel_ready will be true after the first confirmation and if there has been at least once a connection.
- Does not set a default channel state, preventing incorrect initial states upon start up.
- Adapts all warning messages accordingly to reflect the new disconnected channel state.


resolves #535
resolves #525 