### PR TITLE
fix: use latest distroless image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM gcr.io/distroless/cc
+FROM gcr.io/distroless/cc-debian11
 
 LABEL "org.opencontainers.image.source"="https://github.com/itchysats/10101"
 LABEL "org.opencontainers.image.authors"="hello@itchysats.network"


### PR DESCRIPTION
resolves #541


Tested locally on a mac with cross-compilation `TARGET_CC=x86_64-linux-musl-gcc cargo build --release --target x86_64-unknown-linux-musl`

