### PR TITLE
fix: Persist seed backup state over restarts

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -280,6 +280,11 @@ class _TenTenOneState extends State<TenTenOneApp> {
       await api.initWallet(path: appSupportDir.path);
       await api.initDb(appDir: appSupportDir.path);
 
+      final isUserSeedBackupConfirmed =
+          await TenTenOneSharedPreferences.instance.isUserSeedBackupConfirmed();
+      final seedBackupModel = context.read<SeedBackupModel>();
+      seedBackupModel.update(isUserSeedBackupConfirmed);
+
       FLog.info(text: "Starting ldk node");
       api
           .runLdk()
@@ -418,6 +423,7 @@ class TenTenOneSharedPreferences {
       TenTenOneSharedPreferences._privateConstructor();
 
   static const firstStartup = "firstStartup";
+  static const userSeedBackupConfirmed = "userSeedBackupConfirmed";
 
   setFirstStartup(bool value) async {
     SharedPreferences myPrefs = await SharedPreferences.getInstance();
@@ -427,5 +433,15 @@ class TenTenOneSharedPreferences {
   Future<bool> isFirstStartup() async {
     SharedPreferences myPrefs = await SharedPreferences.getInstance();
     return myPrefs.getBool(firstStartup) == null ? true : false;
+  }
+
+  setUserSeedBackupConfirmed(bool value) async {
+    SharedPreferences myPrefs = await SharedPreferences.getInstance();
+    myPrefs.setBool(userSeedBackupConfirmed, value);
+  }
+
+  Future<bool> isUserSeedBackupConfirmed() async {
+    SharedPreferences myPrefs = await SharedPreferences.getInstance();
+    return myPrefs.getBool(userSeedBackupConfirmed) ?? false;
   }
 }

--- a/lib/models/seed_backup_model.dart
+++ b/lib/models/seed_backup_model.dart
@@ -3,8 +3,8 @@ import 'package:flutter/material.dart';
 class SeedBackupModel extends ChangeNotifier {
   bool backup = false;
 
-  void update() {
-    backup = true;
+  void update(bool newState) {
+    backup = newState;
     super.notifyListeners();
   }
 }

--- a/lib/wallet/seed.dart
+++ b/lib/wallet/seed.dart
@@ -2,6 +2,7 @@ import 'package:f_logs/f_logs.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_rust_bridge/flutter_rust_bridge.dart';
 import 'package:provider/provider.dart';
+import 'package:ten_ten_one/main.dart';
 import 'package:ten_ten_one/models/seed_backup_model.dart';
 import 'package:go_router/go_router.dart';
 
@@ -145,7 +146,9 @@ class _SeedState extends State<Seed> {
                           onPressed: checked
                               ? () {
                                   final seedBackupModel = context.read<SeedBackupModel>();
-                                  seedBackupModel.update();
+                                  seedBackupModel.update(true);
+                                  TenTenOneSharedPreferences.instance
+                                      .setUserSeedBackupConfirmed(true);
                                   context.go('/');
                                 }
                               : null,


### PR DESCRIPTION
Store the value in flutter shared preferences so that we don't prompt the user
to backup the seed after each restart.