### PR TITLE
Revert "fix: Set initial value to takerChannelAmount"

### DIFF
--- a/lib/wallet/open_channel.dart
+++ b/lib/wallet/open_channel.dart
@@ -24,7 +24,7 @@ class OpenChannel extends StatefulWidget {
 }
 
 class _OpenChannelState extends State<OpenChannel> {
-  int takerChannelAmount = OpenChannel.maxChannelAmount;
+  int takerChannelAmount = 0;
   bool submitting = false;
 
   final _formKey = GlobalKey<FormState>();
@@ -92,7 +92,7 @@ class _OpenChannelState extends State<OpenChannel> {
                           TextFormField(
                             initialValue: ThousandsSeparatorInputFormatter()
                                 .formatEditUpdate(TextEditingValue.empty,
-                                    TextEditingValue(text: takerChannelAmount.toString()))
+                                    TextEditingValue(text: maxTakerChannelAmount.toString()))
                                 .text,
                             readOnly: submitting,
                             keyboardType: TextInputType.number,


### PR DESCRIPTION
Sorry, this is actually incorrect!
The maximum amount should not be set to the max channel amount of `500.000` initially, the maximum changes depending on the balance changing!

Reverts itchysats/10101#538