### PR TITLE
Add fallback to `mailto` URI if `FlutterEmailSender` fails

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -18,6 +18,10 @@
             <action android:name="android.intent.action.SENDTO" />
             <data android:scheme="mailto" />
         </intent>
+        <intent>
+            <action android:name="android.intent.action.SEND" />
+            <data android:scheme="mailto" />
+        </intent>
     </queries>
 
    <!-- NOTE extractNativeLibs is optional; only to have a better backtrace in debug mode. https://github.com/rust-lang/backtrace-rs/issues/442#issuecomment-942279097 -->
@@ -54,6 +58,14 @@
             <intent-filter>
                 <action android:name="android.intent.action.MAIN"/>
                 <category android:name="android.intent.category.LAUNCHER"/>
+            </intent-filter>
+            <intent-filter>
+                <action android:name="android.intent.action.SEND" />
+                <data android:scheme="mailto" />
+            </intent-filter>
+            <intent-filter>
+                <action android:name="android.intent.action.SENDTO" />
+                <data android:scheme="mailto" />
             </intent-filter>
         </activity>
         <!-- Don't delete the meta-data below.

--- a/lib/utilities/feedback.dart
+++ b/lib/utilities/feedback.dart
@@ -6,6 +6,7 @@ import 'package:f_logs/model/flog/flog.dart';
 import 'package:feedback/feedback.dart';
 import 'package:flutter_email_sender/flutter_email_sender.dart';
 import 'package:path_provider/path_provider.dart';
+import 'package:url_launcher/url_launcher.dart';
 
 Future<void> submitFeedback(UserFeedback feedback) async {
   final screenshotFilePath = await writeImageToStorage(feedback.screenshot);
@@ -25,14 +26,42 @@ Future<void> submitFeedback(UserFeedback feedback) async {
     info = deviceInfo.name! + ", " + deviceInfo.systemName! + " " + deviceInfo.systemVersion!;
   }
 
+  const feedbackEmail = "10101-devs@coblox.tech";
+  const subject = "10101 Feedback";
+  final body = feedback.text + '\n\n----------\n' + info;
+
   final Email email = Email(
-    body: feedback.text + '\n\n----------\n' + info,
-    subject: '10101 Feedback',
-    recipients: ['10101-devs@coblox.tech'],
+    body: body,
+    subject: subject,
+    recipients: [feedbackEmail],
     attachmentPaths: [screenshotFilePath, logs.path],
     isHTML: false,
   );
-  await FlutterEmailSender.send(email);
+  try {
+    await FlutterEmailSender.send(email);
+  } on Exception catch (e) {
+    // fallback to using mailto link
+    // We cannot auto-attach images with this, but the user will still be able to provide text feedback
+    // We add a message that adds the exception to the body text.
+    final Uri emailLaunchUri = Uri(
+      scheme: 'mailto',
+      path: feedbackEmail,
+      queryParameters: {
+        'subject': subject,
+        'body': body +
+            '\n\n----------\n' +
+            "Could not auto-attach images. Had to fallback to mailto link because: $e"
+      },
+    );
+
+    if (await canLaunchUrl(emailLaunchUri)) {
+      await launchUrl(emailLaunchUri);
+    } else {
+      // If we are unable to use mailto we throw the original exception because it likely contains more useful information.
+      // If canLaunchUrl returns false this means there is likely no mail application configured, or we are unable to read the intent
+      rethrow;
+    }
+  }
 }
 
 Future<String> writeImageToStorage(Uint8List feedbackScreenshot) async {

--- a/lib/wallet/wallet_dashboard.dart
+++ b/lib/wallet/wallet_dashboard.dart
@@ -103,7 +103,12 @@ class _WalletDashboardState extends State<WalletDashboard> {
             side: BorderSide(width: 1.0, color: Theme.of(context).primaryColor)),
         child: const Text('Provide feedback'),
         onPressed: () {
-          BetterFeedback.of(context).show(submitFeedback);
+          try {
+            BetterFeedback.of(context).show(submitFeedback);
+          } on Exception catch (e) {
+            ScaffoldMessenger.of(context).showSnackBar(
+                SnackBar(content: Text('Failed to share feedback via email app because: $e')));
+          }
         },
       ));
       widgets.add(const SizedBox(height: 10));


### PR DESCRIPTION
We unfortunately cannot attach images then, but the user can still send text feedback.

This helps to some extend, but does not solve https://github.com/itchysats/10101/issues/530 on my phone.
It might help with iOS - maybe you can give it a try @luckysori 