### PR TITLE
Make sure balance looks good on all screens

### DIFF
--- a/lib/service_placeholders.dart
+++ b/lib/service_placeholders.dart
@@ -19,7 +19,7 @@ class ServicePlaceholder extends StatelessWidget {
     return Scaffold(
         drawer: const Menu(),
         appBar: PreferredSize(
-            child: const AppBarWithBalance(balanceSelector: balanceSelector),
+            child: const SafeArea(child: AppBarWithBalance(balanceSelector: balanceSelector)),
             preferredSize: Size.fromHeight(balanceSelector.preferredHeight)),
         body: SafeArea(
           child: Padding(


### PR DESCRIPTION
On screens with notch it might otherwise be partly covered.

I noticed that the placeholder screen does not properly make sure the balance is in the right place. This is what we did for the other screens to fix this.