### PR TITLE
Display `confirmed` Bitcoin balance instead of `total`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -652,6 +652,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "dart-sys"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42fe64308f2072bb94ecd8f7557f9ac01b69d86e6199bac24be0f091ad74b092"
+
+[[package]]
 name = "devise"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -789,19 +795,23 @@ dependencies = [
 
 [[package]]
 name = "flutter_rust_bridge"
-version = "1.51.0"
+version = "1.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a46a779310d708f39fdac03654a501fe03c83f058c3ff23bb2ec819e0a519ac6"
+checksum = "f841f90e5d04d119e148cafc1118aa1bf67943a6e1e2587b96ca7db4919543e5"
 dependencies = [
  "allo-isolate",
  "anyhow",
  "build-target",
  "bytemuck",
+ "cc",
  "chrono",
  "console_error_panic_hook",
+ "dart-sys",
  "flutter_rust_bridge_macros",
  "js-sys",
  "lazy_static",
+ "libc",
+ "log",
  "parking_lot 0.12.1",
  "threadpool",
  "wasm-bindgen",

--- a/lib/balance.dart
+++ b/lib/balance.dart
@@ -15,7 +15,7 @@ class Balance extends StatelessWidget {
   Widget build(BuildContext context) {
     return Consumer2<LightningBalance, BitcoinBalance>(
       builder: (context, lightningBalance, bitcoinBalance, child) {
-        var bitcoinBalanceTotalDisplay = bitcoinBalance.total().display(currency: Currency.sat);
+        var bitcoinBalanceDisplay = bitcoinBalance.confirmed.display(currency: Currency.sat);
         var bitcoinBalanceConfirmedDisplay =
             bitcoinBalance.confirmed.display(currency: Currency.sat);
         var bitcoinBalancePendingDisplay = bitcoinBalance.pending().display(currency: Currency.sat);
@@ -34,8 +34,8 @@ class Balance extends StatelessWidget {
               ],
             ),
             child: BalanceRow(
-                value: bitcoinBalanceTotalDisplay.value,
-                unit: bitcoinBalanceTotalDisplay.unit,
+                value: bitcoinBalanceDisplay.value,
+                unit: bitcoinBalanceDisplay.unit,
                 icon: Icons.link,
                 smaller: balanceSelector == BalanceSelector.both));
         var lightningBalanceWidget = BalanceRow(

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -309,7 +309,7 @@ packages:
       name: flutter_rust_bridge
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.51.0"
+    version: "1.53.0"
   flutter_speed_dial:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -7,7 +7,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  flutter_rust_bridge: ^1.51.0
+  flutter_rust_bridge: ^1.53.0
   url_launcher: ^6.1.7
   cupertino_icons: ^1.0.5
   freezed_annotation: ^2.1.0

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -16,7 +16,7 @@ bdk-ldk = "0.1.0"
 bip39 = "1.0.1"
 bitcoin-bech32 = "0.12"
 chrono = "0.4.22" # TODO: Remove this dependency to use `time` crate instead
-flutter_rust_bridge = "1.51.0"
+flutter_rust_bridge = "1.53.0"
 futures = "0.3"
 hkdf = "0.12"
 lightning = { version = "0.0.112", features = ["max_level_trace"] }


### PR DESCRIPTION
Displaying the total balance was a great idea, but it causes awkwardness because we then prominently display the maker amount being sent to the taker in the balance upon opening a channel. We cannot easily overcome this problem in the current version, so it's better to display only the confirmed balance prominently.

Additionally this causes awkwardness when we run into a channel force close, because the balance is not `0`, but when trying to open a new channel we can only use `0`, because our displayed balance is actually not usable.

---

@luckysori great composition, I think this is literally the only place I have to change :)