### PR TITLE
Use async mutexes

### DIFF
--- a/macos/Podfile.lock
+++ b/macos/Podfile.lock
@@ -4,6 +4,8 @@ PODS:
   - FlutterMacOS (1.0.0)
   - mobile_scanner (0.0.1):
     - FlutterMacOS
+  - package_info_plus (0.0.1):
+    - FlutterMacOS
   - path_provider_macos (0.0.1):
     - FlutterMacOS
   - shared_preferences_macos (0.0.1):
@@ -15,6 +17,7 @@ DEPENDENCIES:
   - device_info_plus (from `Flutter/ephemeral/.symlinks/plugins/device_info_plus/macos`)
   - FlutterMacOS (from `Flutter/ephemeral`)
   - mobile_scanner (from `Flutter/ephemeral/.symlinks/plugins/mobile_scanner/macos`)
+  - package_info_plus (from `Flutter/ephemeral/.symlinks/plugins/package_info_plus/macos`)
   - path_provider_macos (from `Flutter/ephemeral/.symlinks/plugins/path_provider_macos/macos`)
   - shared_preferences_macos (from `Flutter/ephemeral/.symlinks/plugins/shared_preferences_macos/macos`)
   - url_launcher_macos (from `Flutter/ephemeral/.symlinks/plugins/url_launcher_macos/macos`)
@@ -26,6 +29,8 @@ EXTERNAL SOURCES:
     :path: Flutter/ephemeral
   mobile_scanner:
     :path: Flutter/ephemeral/.symlinks/plugins/mobile_scanner/macos
+  package_info_plus:
+    :path: Flutter/ephemeral/.symlinks/plugins/package_info_plus/macos
   path_provider_macos:
     :path: Flutter/ephemeral/.symlinks/plugins/path_provider_macos/macos
   shared_preferences_macos:
@@ -37,6 +42,7 @@ SPEC CHECKSUMS:
   device_info_plus: 5401765fde0b8d062a2f8eb65510fb17e77cf07f
   FlutterMacOS: ae6af50a8ea7d6103d888583d46bd8328a7e9811
   mobile_scanner: 35dc92ffdbd7934b0dbc411b1c731bc2ef23c2dc
+  package_info_plus: 02d7a575e80f194102bef286361c6c326e4c29ce
   path_provider_macos: 3c0c3b4b0d4a76d2bf989a913c2de869c5641a19
   shared_preferences_macos: a64dc611287ed6cbe28fd1297898db1336975727
   url_launcher_macos: 597e05b8e514239626bcf4a850fcf9ef5c856ec3

--- a/maker/src/main.rs
+++ b/maker/src/main.rs
@@ -36,11 +36,14 @@ async fn main() -> Result<()> {
             .await
             .expect("lightning node to run");
 
-        let node_info = wallet::get_node_info().expect("To get node id for maker");
+        let node_info = wallet::get_node_info()
+            .await
+            .expect("To get node id for maker");
         let public_key = node_info.node_id;
         let listening_address = format!("{public_key}@{lightning_p2p_address}");
         tracing::info!(listening_address, "Listening on");
         let address = wallet::get_address()
+            .await
             .expect("To get a new address")
             .to_string();
         tracing::info!(address, "New address");
@@ -48,11 +51,11 @@ async fn main() -> Result<()> {
         loop {
             let started = Instant::now();
 
-            if let Err(e) = wallet::sync() {
+            if let Err(e) = wallet::sync().await {
                 tracing::error!("Wallet sync failed: {e:#}");
             }
 
-            let wallet_result = wallet::get_balance();
+            let wallet_result = wallet::get_balance().await;
             let duration = started.elapsed();
             let sync_time_in_seconds = duration.as_secs();
             match wallet_result {

--- a/rust/src/api.rs
+++ b/rust/src/api.rs
@@ -85,8 +85,9 @@ pub enum ChannelState {
     Available,
 }
 
-pub fn get_channel_state() -> ChannelState {
-    match wallet::get_first_channel_details() {
+#[tokio::main(flavor = "current_thread")]
+pub async fn get_channel_state() -> ChannelState {
+    match wallet::get_first_channel_details().await {
         Some(channel_details) => {
             if channel_details.is_usable {
                 ChannelState::Available
@@ -154,24 +155,28 @@ pub async fn run_ldk() -> Result<()> {
     Ok(())
 }
 
-pub fn get_balance() -> Result<Balance> {
-    wallet::get_balance()
+#[tokio::main(flavor = "current_thread")]
+pub async fn get_balance() -> Result<Balance> {
+    wallet::get_balance().await
 }
 
-pub fn sync() -> Result<()> {
-    wallet::sync()
+#[tokio::main(flavor = "current_thread")]
+pub async fn sync() -> Result<()> {
+    wallet::sync().await
 }
 
-pub fn get_address() -> Result<Address> {
-    Ok(Address::new(wallet::get_address()?.to_string()))
+#[tokio::main(flavor = "current_thread")]
+pub async fn get_address() -> Result<Address> {
+    Ok(Address::new(wallet::get_address().await?.to_string()))
 }
 
 pub fn maker_peer_info() -> String {
     config::maker_peer_info().to_string()
 }
 
-pub fn node_id() -> Result<String> {
-    wallet::node_id().map(|pk| pk.to_string())
+#[tokio::main(flavor = "current_thread")]
+pub async fn node_id() -> Result<String> {
+    wallet::node_id().await.map(|pk| pk.to_string())
 }
 
 pub fn network() -> SyncReturn<String> {
@@ -190,11 +195,12 @@ pub async fn close_channel() -> Result<()> {
     wallet::close_channel(peer_info.pubkey, false).await
 }
 
-pub fn send_to_address(address: String, amount: u64) -> Result<String> {
+#[tokio::main(flavor = "current_thread")]
+pub async fn send_to_address(address: String, amount: u64) -> Result<String> {
     anyhow::ensure!(!address.is_empty(), "cannot send to an empty address");
     let address = address.parse()?;
 
-    let txid = wallet::send_to_address(address, amount)?;
+    let txid = wallet::send_to_address(address, amount).await?;
     let txid = txid.to_string();
 
     Ok(txid)
@@ -227,9 +233,7 @@ pub async fn call_faucet(address: String) -> Result<String> {
 
 #[tokio::main(flavor = "current_thread")]
 pub async fn get_fee_recommendation() -> Result<u32> {
-    let fee_recommendation = wallet::get_fee_recommendation()?;
-
-    Ok(fee_recommendation)
+    wallet::get_fee_recommendation().await
 }
 
 /// Settles a CFD with the given taker and maker amounts in sats
@@ -273,10 +277,11 @@ pub fn init_logging(sink: StreamSink<logger::LogEntry>) {
     logger::create_log_stream(sink)
 }
 
-pub fn get_seed_phrase() -> Result<Vec<String>> {
+#[tokio::main(flavor = "current_thread")]
+pub async fn get_seed_phrase() -> Result<Vec<String>> {
     // The flutter rust bridge generator unfortunately complains when wrapping a ZeroCopyBuffer with
     // a Result. Hence we need to copy here (data isn't too big though, so that should be ok).
-    wallet::get_seed_phrase()
+    wallet::get_seed_phrase().await
 }
 
 #[tokio::main(flavor = "current_thread")]

--- a/rust/src/cfd/open.rs
+++ b/rust/src/cfd/open.rs
@@ -23,7 +23,7 @@ pub async fn open(order: &Order) -> Result<()> {
         "Opening CFD",
     );
 
-    let channel_manager = wallet::get_channel_manager()?;
+    let channel_manager = wallet::get_channel_manager().await?;
     let channels = channel_manager.list_channels();
 
     tracing::info!("Channels: {channels:?}");

--- a/rust/src/cfd/settle.rs
+++ b/rust/src/cfd/settle.rs
@@ -27,7 +27,7 @@ pub async fn settle(cfd: &Cfd, offer: &Offer) -> Result<()> {
         .to_u64()
         .expect("decimal to fit into u64");
 
-    let channel_manager = wallet::get_channel_manager()?;
+    let channel_manager = wallet::get_channel_manager().await?;
 
     let custom_output_id = base64::decode(&cfd.custom_output_id)?;
     let custom_output_id: [u8; 32] = custom_output_id

--- a/rust/src/connection.rs
+++ b/rust/src/connection.rs
@@ -7,7 +7,7 @@ use anyhow::Result;
 pub async fn keep_alive() -> Result<()> {
     let mut connected = false;
     loop {
-        if !connected || !is_first_channel_usable() {
+        if !connected || !is_first_channel_usable().await {
             connected = connect().await?;
         }
 


### PR DESCRIPTION
With sync mutex, if a lock was held at the time another thread requested access
to the wallet, the request would return an error. This resulted in making it the
caller's responsibility to reschedule the request.

With an async mutex, the call will wait until the previous lock goes
out-of-scope and then acquire the lock.

This is not a problem, because we only acquire the lock to share a access to
underlying resources by calling `clone()`, therefore there should be no deadlocks.

The small price we pay for it is the overhead of `current_thread` tokio runtimes
in a few more places in the Rust API for flutter.