### PR TITLE
Add back-to-dashboard button to the balance app-bar

### DIFF
--- a/lib/app_bar_with_balance.dart
+++ b/lib/app_bar_with_balance.dart
@@ -1,7 +1,10 @@
 import 'package:flutter/material.dart' hide Divider;
+import 'package:go_router/go_router.dart';
+import 'package:provider/provider.dart';
 import 'package:ten_ten_one/utilities/divider.dart';
 
 import 'package:ten_ten_one/balance.dart';
+import 'package:ten_ten_one/wallet/wallet_change_notifier.dart';
 
 extension BalanceSelectorExtension on BalanceSelector {
   static const preferredHeightVals = {
@@ -23,6 +26,27 @@ class AppBarWithBalance extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final currentRoute = GoRouter.of(context).location;
+    WalletChangeNotifier walletChangeNotifier = context.watch<WalletChangeNotifier>();
+    final walletIndex = walletChangeNotifier.selectedIndex;
+
+    var actionButton = <Widget>[];
+
+    final icon = currentRoute == '/' ? Icons.home : Icons.wallet;
+
+    if (!(currentRoute == '/' && walletIndex == 0)) {
+      actionButton = [
+        IconButton(
+          icon: Icon(icon),
+          tooltip: 'Wallet Dashboard',
+          onPressed: () {
+            walletChangeNotifier.update(0);
+            GoRouter.of(context).go('/');
+          },
+        )
+      ];
+    }
+
     return Column(
       crossAxisAlignment: CrossAxisAlignment.stretch,
       children: [
@@ -31,6 +55,7 @@ class AppBarWithBalance extends StatelessWidget {
             elevation: 0,
             backgroundColor: Colors.transparent,
             iconTheme: const IconThemeData(color: Colors.black),
+            actions: actionButton,
           ),
           Padding(
             padding: const EdgeInsets.only(left: 20.0, right: 20.0, top: 20.0, bottom: 10.0),

--- a/lib/app_bar_with_balance.dart
+++ b/lib/app_bar_with_balance.dart
@@ -32,12 +32,10 @@ class AppBarWithBalance extends StatelessWidget {
 
     var actionButton = <Widget>[];
 
-    final icon = currentRoute == '/' ? Icons.home : Icons.wallet;
-
     if (!(currentRoute == '/' && walletIndex == 0)) {
       actionButton = [
         IconButton(
-          icon: Icon(icon),
+          icon: const Icon(Icons.wallet),
           tooltip: 'Wallet Dashboard',
           onPressed: () {
             walletChangeNotifier.update(0);

--- a/lib/wallet/wallet.dart
+++ b/lib/wallet/wallet.dart
@@ -45,13 +45,7 @@ class _WalletState extends State<Wallet> {
           currentIndex: walletChangeNotifier.selectedIndex,
           selectedItemColor: Theme.of(context).colorScheme.primary,
           onTap: (index) {
-            setState(() {
-              // setting the selected index should be sufficient but for some reason
-              // this is not triggering a rebuild even though the cfd trading state
-              // is watched. A manual re-rendering is triggered through the setState
-              // hook.
-              walletChangeNotifier.selectedIndex = index;
-            });
+            walletChangeNotifier.update(index);
           },
         ));
   }

--- a/lib/wallet/wallet.dart
+++ b/lib/wallet/wallet.dart
@@ -30,7 +30,7 @@ class _WalletState extends State<Wallet> {
         bottomNavigationBar: BottomNavigationBar(
           items: const <BottomNavigationBarItem>[
             BottomNavigationBarItem(
-              icon: Icon(Icons.home),
+              icon: Icon(Icons.wallet),
               label: 'Dashboard',
             ),
             BottomNavigationBarItem(

--- a/lib/wallet/wallet_change_notifier.dart
+++ b/lib/wallet/wallet_change_notifier.dart
@@ -3,4 +3,9 @@ import 'package:flutter/material.dart';
 /// Responsible for managing the state across the different Wallet screens.
 class WalletChangeNotifier extends ChangeNotifier {
   int selectedIndex = 0;
+
+  update(int index) {
+    selectedIndex = index;
+    super.notifyListeners();
+  }
 }


### PR DESCRIPTION
resolves #412 

If we are on the dashboard the button is not shown. If we are within lightning or bitcoin wallet the button displays home icon. If we are in any other screen that contains the balance on the top (trade, placeholder) we display a `wallet` icon.

This makes it easy to jump back to the dashboard.

![2022-12-07 14 28 18](https://user-images.githubusercontent.com/5557790/206081106-2e2fc3ee-251d-43f8-943a-cbd6d0b035b9.gif)
