### PR TITLE
Do not wrap `Wallet` in mutex

### DIFF
--- a/maker/src/main.rs
+++ b/maker/src/main.rs
@@ -36,7 +36,7 @@ async fn main() -> Result<()> {
             .await
             .expect("lightning node to run");
 
-        let node_info = wallet::get_node_info().expect("To get node id for maker");
+        let node_info = wallet::get_node_info();
         let public_key = node_info.node_id;
         let listening_address = format!("{public_key}@{lightning_p2p_address}");
         tracing::info!(listening_address, "Listening on");

--- a/rust/src/api.rs
+++ b/rust/src/api.rs
@@ -170,8 +170,8 @@ pub fn maker_peer_info() -> String {
     config::maker_peer_info().to_string()
 }
 
-pub fn node_id() -> Result<String> {
-    wallet::node_id().map(|pk| pk.to_string())
+pub fn node_id() -> String {
+    wallet::node_id().to_string()
 }
 
 pub fn network() -> SyncReturn<String> {
@@ -273,7 +273,7 @@ pub fn init_logging(sink: StreamSink<logger::LogEntry>) {
     logger::create_log_stream(sink)
 }
 
-pub fn get_seed_phrase() -> Result<Vec<String>> {
+pub fn get_seed_phrase() -> Vec<String> {
     // The flutter rust bridge generator unfortunately complains when wrapping a ZeroCopyBuffer with
     // a Result. Hence we need to copy here (data isn't too big though, so that should be ok).
     wallet::get_seed_phrase()

--- a/rust/src/cfd/open.rs
+++ b/rust/src/cfd/open.rs
@@ -23,7 +23,7 @@ pub async fn open(order: &Order) -> Result<()> {
         "Opening CFD",
     );
 
-    let channel_manager = wallet::get_channel_manager()?;
+    let channel_manager = wallet::get_channel_manager();
     let channels = channel_manager.list_channels();
 
     tracing::info!("Channels: {channels:?}");

--- a/rust/src/cfd/settle.rs
+++ b/rust/src/cfd/settle.rs
@@ -27,7 +27,7 @@ pub async fn settle(cfd: &Cfd, offer: &Offer) -> Result<()> {
         .to_u64()
         .expect("decimal to fit into u64");
 
-    let channel_manager = wallet::get_channel_manager()?;
+    let channel_manager = wallet::get_channel_manager();
 
     let custom_output_id = base64::decode(&cfd.custom_output_id)?;
     let custom_output_id: [u8; 32] = custom_output_id


### PR DESCRIPTION
We are never actually mutating the `Wallet` after it has been initialised, so it seems like we don't need a mutex to control access to this resource.

This makes the code a bit simpler and maybe faster since we won't be stuck waiting for some other function to release a mutex guard before we can use the `Wallet`.

---

I've tested it locally a few times and I didn't encounter any trouble.