### PR TITLE
Revert "Update flutter rust bridge"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -652,12 +652,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "dart-sys"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42fe64308f2072bb94ecd8f7557f9ac01b69d86e6199bac24be0f091ad74b092"
-
-[[package]]
 name = "devise"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -795,23 +789,19 @@ dependencies = [
 
 [[package]]
 name = "flutter_rust_bridge"
-version = "1.53.0"
+version = "1.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f841f90e5d04d119e148cafc1118aa1bf67943a6e1e2587b96ca7db4919543e5"
+checksum = "a46a779310d708f39fdac03654a501fe03c83f058c3ff23bb2ec819e0a519ac6"
 dependencies = [
  "allo-isolate",
  "anyhow",
  "build-target",
  "bytemuck",
- "cc",
  "chrono",
  "console_error_panic_hook",
- "dart-sys",
  "flutter_rust_bridge_macros",
  "js-sys",
  "lazy_static",
- "libc",
- "log",
  "parking_lot 0.12.1",
  "threadpool",
  "wasm-bindgen",

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -309,7 +309,7 @@ packages:
       name: flutter_rust_bridge
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.53.0"
+    version: "1.51.0"
   flutter_speed_dial:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -7,7 +7,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  flutter_rust_bridge: ^1.53.0
+  flutter_rust_bridge: ^1.51.0
   url_launcher: ^6.1.7
   cupertino_icons: ^1.0.5
   freezed_annotation: ^2.1.0

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -16,7 +16,7 @@ bdk-ldk = "0.1.0"
 bip39 = "1.0.1"
 bitcoin-bech32 = "0.12"
 chrono = "0.4.22" # TODO: Remove this dependency to use `time` crate instead
-flutter_rust_bridge = "1.53.0"
+flutter_rust_bridge = "1.51.0"
 futures = "0.3"
 hkdf = "0.12"
 lightning = { version = "0.0.112", features = ["max_level_trace"] }


### PR DESCRIPTION
This reverts commit 97f358b45556d752c81e5687343511b890435a8b.

The following error will be thrown with the newest flutter rust bridge version. Reverting for now, as I did not find a quick fix for it.

```
Analyzing 10101...                                                      

  error • Missing concrete implementations of 'FlutterRustBridgeWireBase.drop_dart_object', 'FlutterRustBridgeWireBase.get_dart_object', and 'FlutterRustBridgeWireBase.new_dart_opaque' •
         lib/bridge_generated/bridge_generated.io.dart:123:7 • non_abstract_class_inherits_abstract_member

1 issue found. (ran in 2.0s)
```
