### PR TITLE
chore: Treat Cargo changes as Rust changes on CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,10 +54,12 @@ jobs:
               - '.github/workflows/**'
               - 'rust/**'
               - 'rust-toolchain.toml'
+              - 'Cargo.*'
             maker:
               - '.github/workflows/**'
               - 'maker/**'
               - 'rust-toolchain.toml'
+              - 'Cargo.*'
             flutter:
               - '.github/workflows/**'
               - 'lib/**'


### PR DESCRIPTION
The big difference is that dependency updates will trigger a CI run for Rust part.