### PR TITLE
fix: use image with glibc 2.35

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM gcr.io/distroless/cc-debian11
+FROM ubuntu:22.04
 
 LABEL "org.opencontainers.image.source"="https://github.com/itchysats/10101"
 LABEL "org.opencontainers.image.authors"="hello@itchysats.network"


### PR DESCRIPTION
It looks like this is the version which is being used on github ci and our distroless container does not provide it.

Resolves https://github.com/itchysats/10101/issues/541