### PR TITLE
chore: Introduce dedicated runtime

### DIFF
--- a/rust/src/connection.rs
+++ b/rust/src/connection.rs
@@ -1,44 +1,36 @@
-use crate::config;
+use crate::lightning::PeerInfo;
 use crate::lightning::PeerManager;
 use bdk::bitcoin::secp256k1::PublicKey;
 use std::sync::Arc;
 use std::time::Duration;
-use tokio::task::JoinHandle;
 
-pub fn spawn(peer_manager: Arc<PeerManager>) -> JoinHandle<()> {
-    // keep connection with maker alive!
-    tokio::spawn(async move {
-        let peer_info = config::maker_peer_info();
-        loop {
-            tracing::info!("Connecting to {peer_info}");
-            match lightning_net_tokio::connect_outbound(
-                Arc::clone(&peer_manager),
-                peer_info.pubkey,
-                peer_info.peer_addr,
-            )
-            .await
-            {
-                Some(connection_closed_future) => {
-                    let mut connection_closed_future = Box::pin(connection_closed_future);
-                    while !is_connected(&peer_manager, peer_info.pubkey) {
-                        if futures::poll!(&mut connection_closed_future).is_ready() {
-                            tracing::warn!("Peer disconnected before we finished the handshake! Retrying in 5 seconds.");
-                            tokio::time::sleep(Duration::from_secs(5)).await;
-                            return;
-                        }
-                        tokio::time::sleep(Duration::from_secs(5)).await;
-                    }
-                    tracing::info!("Successfully connected to {peer_info}");
-                    connection_closed_future.await;
-                    tracing::warn!("Lost connection to maker, retrying immediately.")
-                }
-                None => {
-                    tracing::warn!("Failed to connect to maker! Retrying in 5 seconds.");
+pub async fn connect(peer_manager: Arc<PeerManager>, peer_info: PeerInfo) {
+    tracing::info!("Connecting to {peer_info}");
+    match lightning_net_tokio::connect_outbound(
+        Arc::clone(&peer_manager),
+        peer_info.pubkey,
+        peer_info.peer_addr,
+    )
+    .await
+    {
+        Some(connection_closed_future) => {
+            let mut connection_closed_future = Box::pin(connection_closed_future);
+            while !is_connected(&peer_manager, peer_info.pubkey) {
+                if futures::poll!(&mut connection_closed_future).is_ready() {
+                    tracing::warn!("Peer disconnected before we finished the handshake! Retrying in 5 seconds.");
                     tokio::time::sleep(Duration::from_secs(5)).await;
+                    return;
                 }
+                tokio::time::sleep(Duration::from_secs(5)).await;
             }
+            tracing::info!("Successfully connected to {peer_info}");
+            connection_closed_future.await;
+            tracing::warn!("Lost connection to maker, retrying immediately.")
         }
-    })
+        None => {
+            tracing::warn!("Failed to connect to maker! Retrying.");
+        }
+    }
 }
 
 fn is_connected(peer_manager: &Arc<PeerManager>, pubkey: PublicKey) -> bool {

--- a/rust/src/lightning.rs
+++ b/rust/src/lightning.rs
@@ -115,7 +115,7 @@ pub struct LightningSystem {
     pub network: Network,
 }
 
-#[derive(Serialize)]
+#[derive(Serialize, Clone, Copy)]
 pub struct PeerInfo {
     pub pubkey: PublicKey,
     pub peer_addr: SocketAddr,
@@ -545,7 +545,7 @@ fn default_user_config() -> UserConfig {
     }
 }
 
-pub async fn run_ldk(system: &LightningSystem) -> Result<BackgroundProcessor> {
+pub fn run_ldk(system: &LightningSystem) -> Result<BackgroundProcessor> {
     let ldk_data_dir = system.data_dir.to_string_lossy().to_string();
 
     let runtime_handle = tokio::runtime::Handle::current();
@@ -630,7 +630,7 @@ pub async fn run_ldk_server(
 
     tracing::info!("Listening on {address}");
 
-    let background_processor = run_ldk(system).await?;
+    let background_processor = run_ldk(system)?;
     Ok((tcp_handle, background_processor))
 }
 

--- a/rust/src/offer.rs
+++ b/rust/src/offer.rs
@@ -1,29 +1,16 @@
-use crate::api::Event;
 use crate::config::maker_endpoint;
 use anyhow::anyhow;
 use anyhow::bail;
 use anyhow::Result;
-use flutter_rust_bridge::StreamSink;
 use reqwest::StatusCode;
 use serde::Deserialize;
 use serde::Serialize;
-use tokio::task::JoinHandle;
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct Offer {
     pub bid: f64,
     pub ask: f64,
     pub index: f64,
-}
-
-pub fn spawn(stream: StreamSink<Event>) -> JoinHandle<()> {
-    tokio::spawn(async move {
-        loop {
-            let offer = get_offer().await.ok();
-            stream.add(Event::Offer(offer));
-            tokio::time::sleep(std::time::Duration::from_secs(5)).await;
-        }
-    })
 }
 
 pub async fn get_offer() -> Result<Offer> {

--- a/rust/src/wallet.rs
+++ b/rust/src/wallet.rs
@@ -238,8 +238,8 @@ impl Wallet {
     }
 
     /// Run the lightning node
-    pub async fn run_ldk(&self) -> Result<BackgroundProcessor> {
-        lightning::run_ldk(&self.lightning).await
+    pub fn run_ldk(&self) -> Result<BackgroundProcessor> {
+        lightning::run_ldk(&self.lightning)
     }
 
     /// Run the lightning node
@@ -418,9 +418,9 @@ pub fn init_wallet(data_dir: &Path) -> Result<()> {
     Ok(())
 }
 
-pub async fn run_ldk() -> Result<BackgroundProcessor> {
+pub fn run_ldk() -> Result<BackgroundProcessor> {
     let wallet = get_wallet();
-    wallet.run_ldk().await
+    wallet.run_ldk()
 }
 
 pub async fn run_ldk_server(address: SocketAddr) -> Result<(JoinHandle<()>, BackgroundProcessor)> {
@@ -485,8 +485,8 @@ pub fn get_seed_phrase() -> Vec<String> {
     get_wallet().seed.get_seed_phrase()
 }
 
-pub fn get_peer_manager() -> Result<Arc<PeerManager>> {
-    Ok(get_wallet().lightning.peer_manager.clone())
+pub fn get_peer_manager() -> Arc<PeerManager> {
+    get_wallet().lightning.peer_manager.clone()
 }
 
 pub async fn send_lightning_payment(invoice: &str) -> Result<()> {


### PR DESCRIPTION
Annotating the function with `#[tokio::main]` killed the runtime after the function completes. Thus we had to block the run function indefinitely for the long living threads to keep going.

This change introduces a runtime managed outside of the function scope and thus allows the `run` function to return bringing the following advantages.

 - We don't block a whole frb worker thread just to run the lightning node, sync tasks, background processor, etc.
 - We are using a multi threaded runtime instead of the current thread
   - allowing to actually join the background processor without blocking all other tasks.
   - making better use of multiple cpu cores.
 - We are not creating a new runtime on every async bridge call.